### PR TITLE
refactor: 统一输出目录策略，并修复目标目录 ACL 不回落（v3.3.0 第一步）

### DIFF
--- a/backend/sidecar.py
+++ b/backend/sidecar.py
@@ -36,6 +36,7 @@ from src.crawler.dynamic_crawler import DynamicCrawler
 from src.exporter.csv_exporter import CSVExporter
 from src.processor.analysis_processor import AnalysisCancelled, AnalysisError, LLMAnalysisProcessor
 from src.processor.data_processor import DataProcessor
+from src.service.paths import analysis_assets_root
 from utils.helpers import ContentType, extract_uid, parse_input
 
 logging.basicConfig(
@@ -411,21 +412,10 @@ class Sidecar:
 
     @staticmethod
     def _analysis_asset_root() -> Path:
-        # Prefer the project root so users can easily find exported assets.
-        candidate = ROOT / "analysis-assets"
-        try:
-            candidate.mkdir(parents=True, exist_ok=True)
-            # Quick writability check
-            (candidate / ".write-test"). touch()
-            (candidate / ".write-test").unlink(missing_ok=True)
-            return candidate
-        except (OSError, PermissionError):
-            pass
-        # Fall back to %LOCALAPPDATA% for installed / non-writable layouts.
-        local_app_data = os.environ.get("LOCALAPPDATA")
-        if local_app_data:
-            return Path(local_app_data) / "BilibiliCrawler" / "analysis-assets"
-        return Path.home() / "AppData" / "Local" / "BilibiliCrawler" / "analysis-assets"
+        # Same root decision as the agent service: project root when writable,
+        # %LOCALAPPDATA% for installed layouts. Kept as a method because the
+        # tests substitute it.
+        return analysis_assets_root()
 
     @staticmethod
     def _safe_file_part(value: Any) -> str:

--- a/src/service/paths.py
+++ b/src/service/paths.py
@@ -1,14 +1,10 @@
 """
-Output directory resolution for headless agent runs.
+Output directory resolution, shared by the desktop sidecar and the agent service.
 
-The policy intentionally mirrors ``Sidecar._analysis_asset_root`` in
-backend/sidecar.py: prefer the project root so users can find their files, and
-fall back to %LOCALAPPDATA% for installed layouts where the project root is not
-writable. Keeping both roots identical means the desktop app and the agent drop
-their output side by side instead of in two unrelated places.
-
-TODO(v3.3.0): collapse this and Sidecar._analysis_asset_root into one helper
-once the sidecar is migrated onto AgentService.
+One policy, in one place: prefer the project root so users can find their files,
+and fall back to %LOCALAPPDATA% for installed layouts where the project root is
+not writable. Both front ends resolve through here, so the desktop app's assets
+and the agent's runs land side by side and the two cannot drift apart.
 """
 from __future__ import annotations
 
@@ -19,15 +15,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 RUNS_DIR_NAME = "analysis-runs"
+ASSETS_DIR_NAME = "analysis-assets"
 RUNS_DIR_ENV = "BILIBILI_AGENT_RUNS_DIR"
 
 
 def _is_writable(candidate: Path) -> bool:
     """Probe writability with a unique, exclusively-created temp file.
 
-    A fixed probe name (as in Sidecar._analysis_asset_root) would delete a real
-    file that happened to share the name, and two processes probing at once
-    would delete each other's probe.
+    A fixed probe name would delete a real file that happened to share it, and
+    two processes probing at once would delete each other's probe.
     """
     try:
         candidate.mkdir(parents=True, exist_ok=True)
@@ -57,3 +53,13 @@ def agent_runs_root() -> Path:
     root = Path(override).expanduser() if override else user_output_root() / RUNS_DIR_NAME
     root.mkdir(parents=True, exist_ok=True)
     return root.resolve()
+
+
+def analysis_assets_root() -> Path:
+    """Return the directory holding the desktop app's per-analysis asset dirs.
+
+    Used by backend/sidecar.py via Sidecar._analysis_asset_root.
+    """
+    root = user_output_root() / ASSETS_DIR_NAME
+    root.mkdir(parents=True, exist_ok=True)
+    return root

--- a/src/service/paths.py
+++ b/src/service/paths.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 
+PRODUCT_DIR_NAME = "BilibiliCrawler"
 RUNS_DIR_NAME = "analysis-runs"
 ASSETS_DIR_NAME = "analysis-assets"
 RUNS_DIR_ENV = "BILIBILI_AGENT_RUNS_DIR"
@@ -35,24 +36,56 @@ def _is_writable(candidate: Path) -> bool:
     return True
 
 
-def user_output_root() -> Path:
-    """Return the writable directory that holds agent output directories."""
-    candidate = ROOT
-    if _is_writable(candidate):
-        return candidate
-
+def candidate_bases() -> list[Path]:
+    """Bases to try, most preferred first."""
+    bases = [ROOT]
     local_app_data = os.environ.get("LOCALAPPDATA")
     if local_app_data:
-        return Path(local_app_data) / "BilibiliCrawler"
-    return Path.home() / "AppData" / "Local" / "BilibiliCrawler"
+        bases.append(Path(local_app_data) / PRODUCT_DIR_NAME)
+    bases.append(Path.home() / "AppData" / "Local" / PRODUCT_DIR_NAME)
+    return bases
+
+
+def output_dir(name: str) -> Path:
+    """Return the first base where `name` itself is writable.
+
+    The probe targets the output directory, not its parent. On Windows an
+    existing subdirectory can carry an ACL its parent does not, so a writable
+    project root is no guarantee that analysis-assets/ inside it can be written
+    -- checking only the parent would pick a directory that then fails on
+    export instead of falling back to %LOCALAPPDATA%.
+    """
+    bases = candidate_bases()
+    for base in bases:
+        target = base / name
+        if _is_writable(target):
+            return target
+    # Nothing was writable; hand back the last resort so the caller surfaces a
+    # real error at write time rather than a confusing empty path.
+    return bases[-1] / name
+
+
+def user_output_root() -> Path:
+    """Return the base directory that holds the output directories.
+
+    Prefer output_dir(): this reports the base only, so it cannot account for a
+    subdirectory whose permissions differ from its parent.
+    """
+    bases = candidate_bases()
+    for base in bases:
+        if _is_writable(base):
+            return base
+    return bases[-1]
 
 
 def agent_runs_root() -> Path:
     """Return the directory that holds one sub-directory per run."""
     override = os.environ.get(RUNS_DIR_ENV, "").strip()
-    root = Path(override).expanduser() if override else user_output_root() / RUNS_DIR_NAME
-    root.mkdir(parents=True, exist_ok=True)
-    return root.resolve()
+    if override:
+        root = Path(override).expanduser()
+        root.mkdir(parents=True, exist_ok=True)
+        return root.resolve()
+    return output_dir(RUNS_DIR_NAME).resolve()
 
 
 def analysis_assets_root() -> Path:
@@ -60,6 +93,4 @@ def analysis_assets_root() -> Path:
 
     Used by backend/sidecar.py via Sidecar._analysis_asset_root.
     """
-    root = user_output_root() / ASSETS_DIR_NAME
-    root.mkdir(parents=True, exist_ok=True)
-    return root
+    return output_dir(ASSETS_DIR_NAME)

--- a/src/service/paths.py
+++ b/src/service/paths.py
@@ -31,8 +31,21 @@ def _is_writable(candidate: Path) -> bool:
         handle, name = tempfile.mkstemp(dir=str(candidate), prefix=".write-probe-")
     except (OSError, PermissionError):
         return False
-    os.close(handle)
-    Path(name).unlink(missing_ok=True)
+
+    probe = Path(name)
+    try:
+        os.close(handle)
+    except OSError:
+        # Already closed or invalid; removal below still decides the verdict.
+        pass
+    try:
+        probe.unlink(missing_ok=True)
+    except (OSError, PermissionError):
+        # A directory we cannot clean up after is not one to write into: an
+        # antivirus scanner holding the file, or a directory that denies
+        # deletes, would otherwise raise out of here instead of falling back,
+        # and leave the probe behind.
+        return False
     return True
 
 
@@ -63,19 +76,6 @@ def output_dir(name: str) -> Path:
     # Nothing was writable; hand back the last resort so the caller surfaces a
     # real error at write time rather than a confusing empty path.
     return bases[-1] / name
-
-
-def user_output_root() -> Path:
-    """Return the base directory that holds the output directories.
-
-    Prefer output_dir(): this reports the base only, so it cannot account for a
-    subdirectory whose permissions differ from its parent.
-    """
-    bases = candidate_bases()
-    for base in bases:
-        if _is_writable(base):
-            return base
-    return bases[-1]
 
 
 def agent_runs_root() -> Path:

--- a/tests/test_sidecar_analysis.py
+++ b/tests/test_sidecar_analysis.py
@@ -1,9 +1,11 @@
 import json
+import os
 import logging
 import io
 import base64
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 from contextlib import redirect_stdout
 
@@ -427,26 +429,66 @@ class SidecarAnalysisTests(unittest.TestCase):
             finally:
                 Sidecar._analysis_asset_root = original_root
 
-    def test_analysis_asset_root_matches_the_shared_path_policy(self) -> None:
-        # The sidecar used to carry its own copy of this root decision. It now
-        # delegates to src/service/paths.py, so this pins the location the
-        # desktop app writes to and keeps the two front ends from drifting.
-        from src.service.paths import ASSETS_DIR_NAME, analysis_assets_root, user_output_root
+    def test_analysis_asset_root_uses_the_project_dir_when_writable(self) -> None:
+        # The sidecar used to carry its own copy of this root decision; it now
+        # delegates to src/service/paths.py. Pins the location the desktop app
+        # writes to, inside a temp ROOT so the repo is not polluted.
+        import src.service.paths as paths
 
-        resolved = Sidecar._analysis_asset_root()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with unittest.mock.patch.object(paths, "ROOT", Path(temp_dir)):
+                resolved = Sidecar._analysis_asset_root()
 
-        self.assertEqual(resolved, analysis_assets_root())
-        self.assertEqual(resolved, user_output_root() / ASSETS_DIR_NAME)
-        self.assertEqual(resolved.name, "analysis-assets")
-        self.assertTrue(resolved.is_dir())
+            self.assertEqual(resolved, Path(temp_dir) / "analysis-assets")
+            self.assertTrue(resolved.is_dir())
+
+    def test_analysis_asset_root_falls_back_when_the_target_dir_is_unwritable(self) -> None:
+        # The regression that a parent-only probe introduced: on Windows an
+        # existing subdirectory can carry an ACL its parent does not. Probing
+        # only the project root would return a directory that then fails on
+        # export, instead of falling back to %LOCALAPPDATA%.
+        import src.service.paths as paths
+
+        with tempfile.TemporaryDirectory() as project, tempfile.TemporaryDirectory() as fallback:
+            project_assets = Path(project) / "analysis-assets"
+            real_is_writable = paths._is_writable
+
+            def deny_target(candidate: Path) -> bool:
+                if candidate == project_assets:
+                    return False          # the subdirectory is denied ...
+                if candidate == Path(project):
+                    return True           # ... while its parent is fine
+                return real_is_writable(candidate)
+
+            with unittest.mock.patch.object(paths, "ROOT", Path(project)), \
+                    unittest.mock.patch.object(paths, "_is_writable", deny_target), \
+                    unittest.mock.patch.dict(
+                        os.environ, {"LOCALAPPDATA": fallback}, clear=False):
+                resolved = Sidecar._analysis_asset_root()
+
+            self.assertEqual(
+                resolved,
+                Path(fallback) / "BilibiliCrawler" / "analysis-assets",
+                "an unwritable target directory must fall back, not be returned anyway",
+            )
+            self.assertNotEqual(resolved, project_assets)
 
     def test_analysis_asset_root_probe_leaves_no_files_behind(self) -> None:
-        root = Sidecar._analysis_asset_root()
-        before = sorted(p.name for p in root.parent.iterdir())
-        Sidecar._analysis_asset_root()
-        after = sorted(p.name for p in root.parent.iterdir())
-        self.assertEqual(before, after)
-        self.assertFalse((root.parent / ".write-test").exists())
+        # The probe runs inside the target directory, so that is where a stray
+        # file would land. The old implementation used a fixed ".write-test"
+        # name there and deleted it unconditionally.
+        import src.service.paths as paths
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with unittest.mock.patch.object(paths, "ROOT", Path(temp_dir)):
+                root = Sidecar._analysis_asset_root()
+                before = sorted(p.name for p in root.iterdir())
+                Sidecar._analysis_asset_root()
+                after = sorted(p.name for p in root.iterdir())
+
+            self.assertEqual(before, after)
+            self.assertFalse((root / ".write-test").exists())
+            self.assertEqual([p.name for p in root.glob(".write-probe-*")], [])
 
     def test_chart_assets_accept_png_file_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_sidecar_analysis.py
+++ b/tests/test_sidecar_analysis.py
@@ -473,6 +473,84 @@ class SidecarAnalysisTests(unittest.TestCase):
             )
             self.assertNotEqual(resolved, project_assets)
 
+    def test_analysis_asset_root_falls_back_past_an_unwritable_local_app_data(self) -> None:
+        # Second fallback branch: the old sidecar returned the %LOCALAPPDATA%
+        # path without probing it, so an unwritable one produced a directory
+        # that simply failed later. Now the home candidate is tried too.
+        import src.service.paths as paths
+
+        with tempfile.TemporaryDirectory() as project, \
+                tempfile.TemporaryDirectory() as local_app_data, \
+                tempfile.TemporaryDirectory() as home:
+            denied = {
+                Path(project) / "analysis-assets",
+                Path(local_app_data) / "BilibiliCrawler" / "analysis-assets",
+            }
+            real_is_writable = paths._is_writable
+
+            def deny(candidate: Path) -> bool:
+                return False if candidate in denied else real_is_writable(candidate)
+
+            with unittest.mock.patch.object(paths, "ROOT", Path(project)), \
+                    unittest.mock.patch.object(paths, "_is_writable", deny), \
+                    unittest.mock.patch.object(paths.Path, "home", staticmethod(lambda: Path(home))), \
+                    unittest.mock.patch.dict(
+                        os.environ, {"LOCALAPPDATA": local_app_data}, clear=False):
+                resolved = Sidecar._analysis_asset_root()
+
+            self.assertEqual(
+                resolved,
+                Path(home) / "AppData" / "Local" / "BilibiliCrawler" / "analysis-assets",
+            )
+
+    def test_analysis_asset_root_without_local_app_data_uses_the_home_candidate(self) -> None:
+        import src.service.paths as paths
+
+        with tempfile.TemporaryDirectory() as project, tempfile.TemporaryDirectory() as home:
+            denied = {Path(project) / "analysis-assets"}
+            real_is_writable = paths._is_writable
+
+            def deny(candidate: Path) -> bool:
+                return False if candidate in denied else real_is_writable(candidate)
+
+            environ = {k: v for k, v in os.environ.items() if k != "LOCALAPPDATA"}
+            with unittest.mock.patch.object(paths, "ROOT", Path(project)), \
+                    unittest.mock.patch.object(paths, "_is_writable", deny), \
+                    unittest.mock.patch.object(paths.Path, "home", staticmethod(lambda: Path(home))), \
+                    unittest.mock.patch.dict(os.environ, environ, clear=True):
+                self.assertNotIn("LOCALAPPDATA", os.environ)
+                resolved = Sidecar._analysis_asset_root()
+
+            self.assertEqual(
+                resolved,
+                Path(home) / "AppData" / "Local" / "BilibiliCrawler" / "analysis-assets",
+            )
+
+    def test_a_probe_that_cannot_be_removed_marks_the_candidate_unusable(self) -> None:
+        # An antivirus scanner holding the probe, or a directory that denies
+        # deletes, must not raise out of the resolver or leave the probe
+        # behind -- it means "do not write here", so the next candidate wins.
+        import src.service.paths as paths
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir)
+            original_unlink = Path.unlink
+
+            def refuse_probe_removal(self, missing_ok=False):
+                if self.name.startswith(".write-probe-"):
+                    raise PermissionError("probe locked by another process")
+                return original_unlink(self, missing_ok=missing_ok)
+
+            with unittest.mock.patch.object(Path, "unlink", refuse_probe_removal):
+                verdict = paths._is_writable(target)
+
+            self.assertFalse(verdict, "an unremovable probe must fail the candidate")
+            # The probe itself is still there because removal genuinely failed;
+            # what matters is that no exception escaped the resolver.
+            leftovers = list(target.glob(".write-probe-*"))
+            for leftover in leftovers:
+                original_unlink(leftover, missing_ok=True)
+
     def test_analysis_asset_root_probe_leaves_no_files_behind(self) -> None:
         # The probe runs inside the target directory, so that is where a stray
         # file would land. The old implementation used a fixed ".write-test"

--- a/tests/test_sidecar_analysis.py
+++ b/tests/test_sidecar_analysis.py
@@ -427,6 +427,27 @@ class SidecarAnalysisTests(unittest.TestCase):
             finally:
                 Sidecar._analysis_asset_root = original_root
 
+    def test_analysis_asset_root_matches_the_shared_path_policy(self) -> None:
+        # The sidecar used to carry its own copy of this root decision. It now
+        # delegates to src/service/paths.py, so this pins the location the
+        # desktop app writes to and keeps the two front ends from drifting.
+        from src.service.paths import ASSETS_DIR_NAME, analysis_assets_root, user_output_root
+
+        resolved = Sidecar._analysis_asset_root()
+
+        self.assertEqual(resolved, analysis_assets_root())
+        self.assertEqual(resolved, user_output_root() / ASSETS_DIR_NAME)
+        self.assertEqual(resolved.name, "analysis-assets")
+        self.assertTrue(resolved.is_dir())
+
+    def test_analysis_asset_root_probe_leaves_no_files_behind(self) -> None:
+        root = Sidecar._analysis_asset_root()
+        before = sorted(p.name for p in root.parent.iterdir())
+        Sidecar._analysis_asset_root()
+        after = sorted(p.name for p in root.parent.iterdir())
+        self.assertEqual(before, after)
+        self.assertFalse((root.parent / ".write-test").exists())
+
     def test_chart_assets_accept_png_file_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             image_path = Path(temp_dir) / "word-cloud.png"


### PR DESCRIPTION
v3.3.0 sidecar 统一的第一步：**把输出目录策略收敛到一处，并修掉目标目录 ACL 场景下不回落的问题**。

> 早先版本的 PR 正文写的是「只去重，不改行为 / 三条分支完全等价」。那个说法不准确，已更正——见下面「行为变化」一节。

`Sidecar._analysis_asset_root` 自带一份「项目根可写就用它，否则回落 `%LOCALAPPDATA%`」的策略，与 `src/service/paths.py` 重复，两个前端可以各自漂移。现在统一走 `paths.output_dir()`，`paths.py` 里的 `TODO(v3.3.0)` 随之消除。

## 行为变化（有意为之，不是纯去重）

| 场景 | 旧 Sidecar | 本 PR |
|---|---|---|
| 项目根可写，`analysis-assets` 子目录被 ACL 拒写 | 返回项目路径，**导出时才失败** | 回落到 `%LOCALAPPDATA%` |
| `%LOCALAPPDATA%` 目标不可写 | 直接返回它，不探测 | 继续尝试 home 候选 |
| 探针无法删除（杀软占用 / 目录禁止删除） | 捕获异常并回落 | 视为该候选不可用，尝试下一个 |
| `agent_runs_root()` 的探测对象 | —（新代码，之前探测父目录） | 探测 `analysis-runs` 本身 |

前两条是这次要修的实质问题：探测父目录不等于探测目标目录，Windows 上子目录可以带有与父目录不同的 ACL。

## 探针本身

旧探针 `touch` 后**无条件删除**固定文件名 `.write-test`：同名真实文件会被删掉，两个进程同时探测也会互删。现在用 `tempfile.mkstemp` 独占创建唯一名；`os.close()` 不会向外抛异常，删除失败则判定该候选不可写并继续回落。注意这里**不保证不留残留**：操作系统真的拒绝删除时，那个唯一名探针会留在原地——能保证的是异常不外抛、不会误删同名真实文件、并且换下一个候选。

## 顺带清理

`user_output_root()` 已无调用者，且保留着另一套「只探父目录」的语义。删除，避免两套策略再次漂移——收敛策略正是这个分支的目的。

## 验证

- Python（venv，含 MCP SDK）：**93 通过**
- Python（全局，未装 mcp）：**78 通过，1 跳过**
- 桌面 TS：**9 通过**
- 确认测试套件不往仓库写 `analysis-assets/` / `analysis-runs/`（先删干净再跑全量，未重新出现）

新增 6 条路径相关测试，覆盖：项目目录可写、目标目录被拒回落、`%LOCALAPPDATA%` 目标被拒再回落、无 `LOCALAPPDATA`、探针不可删除、探针不留残留。

其中两条做了反向验证（先移除修复确认变红，再装回确认转绿）：

- 目标目录回落 → `AssertionError: ... must fall back, not be returned anyway`
- 探针清理 → `PermissionError: probe locked by another process` 直接逃逸出解析器

## 不在本 PR 内

爬取/分析编排下沉到 `AgentService` 留给下一个 PR，扫码登录和动态爬取再之后。这样 v3.1.1 刚稳定的桌面取消行为不会和这次的路径改动混在一起回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
