### PR TITLE
test: 迁移前的行为基线（v3.3.0 第二步 · 阶段 1，无生产代码改动）

### DIFF
--- a/tests/test_sidecar_characterization.py
+++ b/tests/test_sidecar_characterization.py
@@ -16,8 +16,11 @@ before the migration rather than after:
 If a change makes one of these fail, that is a behaviour change and belongs in
 its own PR with its own justification -- not in the migration.
 """
+import base64
+import tempfile
 import threading
 import unittest
+from pathlib import Path
 
 from backend.sidecar import Sidecar, SidecarServices
 from src.processor.analysis_processor import AnalysisCancelled
@@ -167,7 +170,7 @@ ANALYSIS_RESULT = {
 
 
 def make(comments=None, error=None, gate=None, processor=None):
-    holder: dict = {}
+    holder: dict = {"created": threading.Event()}
 
     def factory(progress):
         # DataProcessor.clean_comments fills defaults in place, so the crawler
@@ -179,6 +182,7 @@ def make(comments=None, error=None, gate=None, processor=None):
             error=error,
             gate=gate,
         )
+        holder["created"].set()
         return holder["crawler"]
 
     services = SidecarServices(
@@ -187,6 +191,30 @@ def make(comments=None, error=None, gate=None, processor=None):
         analysis_processor=processor or StubAnalysisProcessor(result=ANALYSIS_RESULT),
     )
     return RecordingSidecar(services), holder
+
+
+def crawler_of(holder: dict, timeout: float = 5.0) -> StubCrawler:
+    """Wait for the worker thread to build the crawler, then return it.
+
+    comments.start returns as soon as the thread is spawned; the factory runs
+    inside that thread. Reading holder["crawler"] straight after handle() is a
+    race that raises KeyError whenever the scheduler is slow.
+    """
+    if not holder["created"].wait(timeout=timeout):
+        raise AssertionError("crawler was never created")
+    crawler = holder["crawler"]
+    if not crawler.entered.wait(timeout=timeout):
+        raise AssertionError("crawler never entered crawl_comments")
+    return crawler
+
+
+def sequence(sidecar: RecordingSidecar) -> list[tuple]:
+    """Every event frame as (event, mode), logs included, in emission order."""
+    return [
+        (frame["event"], frame.get("mode"))
+        for frame in sidecar.frames
+        if frame.get("kind") == "event"
+    ]
 
 
 def drain(sidecar: RecordingSidecar, timeout: float = 5.0) -> None:
@@ -267,11 +295,14 @@ class CommentCrawlBaseline(unittest.TestCase):
         sidecar, _ = make(comments=[])
         sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
 
-        self.assertFalse(sidecar.has("error", "comments"))
+        # Exact sequence: an extra frame or a reordering is a contract change.
+        self.assertEqual(sequence(sidecar),
+                         [("stats", "comments"), ("finished", "comments"), ("progress", "comments")])
         finished = sidecar.event("finished", "comments")
         self.assertEqual(finished["count"], 0)
         self.assertEqual(finished["stats"]["total"], 0)
-        self.assertEqual(sidecar.event("progress", "comments")["status"], "idle")
+        idle = sidecar.event("progress", "comments")
+        self.assertEqual((idle["status"], idle["percent"]), ("idle", 100))
 
     def test_failure_emits_error_without_finished_but_still_goes_idle(self) -> None:
         sidecar, _ = make(error=RuntimeError("接口返回 412"))
@@ -282,11 +313,14 @@ class CommentCrawlBaseline(unittest.TestCase):
             sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
         self.assertIn("comments task failed", "\n".join(captured.output))
 
-        self.assertFalse(sidecar.has("finished", "comments"))
+        # No stats frame on this path, and no finished -- just error then idle.
+        self.assertEqual(sequence(sidecar),
+                         [("error", "comments"), ("progress", "comments")])
         error = sidecar.event("error", "comments")
         self.assertEqual(error["mode"], "comments")
         self.assertIn("412", error["message"])
-        self.assertEqual(sidecar.event("progress", "comments")["status"], "idle")
+        idle = sidecar.event("progress", "comments")
+        self.assertEqual((idle["status"], idle["percent"]), ("idle", 100))
 
     def test_comment_context_is_recorded_for_asset_naming(self) -> None:
         sidecar, _ = make(comments=[COMMENT_A])
@@ -340,13 +374,13 @@ class CommentStopBaseline(unittest.TestCase):
 
         sidecar.handle({"id": "req-1", "method": "comments.start",
                         "params": {"input": "BV1xx411c7mD", "max_pages": 5}})
-        self.assertTrue(holder["crawler"].entered.wait(timeout=5))
+        crawler = crawler_of(holder)
 
         # task.stop emits its frames on the calling thread, so the crawler is
         # released only afterwards: "stopping" then precedes "idle" because the
         # test ordered them, not because it won a race against the worker.
         sidecar.handle({"id": "req-2", "method": "task.stop", "params": {}})
-        self.assertTrue(holder["crawler"].stopped)
+        self.assertTrue(crawler.stopped)
         # Stopping a crawl must not arm the analysis cancel flag (v3.1.1).
         self.assertFalse(sidecar._analysis_cancel.is_set())
         gate.set()
@@ -357,17 +391,30 @@ class CommentStopBaseline(unittest.TestCase):
         self.assertEqual(sidecar.event("finished", "comments")["count"], 1)
         self.assertEqual([row["comment_id"] for row in sidecar._last_comments], [1])
 
-        statuses = [frame["status"] for frame in sidecar.frames
-                    if frame.get("event") == "progress" and frame.get("mode") == "comments"]
-        self.assertIn("stopping", statuses)
-        self.assertEqual(statuses[-1], "idle")
+        # Full sequence, both threads: start frames, the stop frames emitted on
+        # the calling thread, then the worker finishing normally.
+        self.assertEqual(sequence(sidecar), [
+            ("progress", "comments"),   # running, 0
+            ("log", None),              # 评论任务已启动
+            ("log", None),              # 正在停止爬取任务...
+            ("progress", "comments"),   # stopping, 0
+            ("stats", "comments"),
+            ("finished", "comments"),
+            ("progress", "comments"),   # idle, 100
+        ])
+        progress_frames = [frame for frame in sidecar.frames
+                           if frame.get("event") == "progress" and frame.get("mode") == "comments"]
+        self.assertEqual(
+            [(frame["status"], frame["percent"]) for frame in progress_frames],
+            [("running", 0), ("stopping", 0), ("idle", 100)],
+        )
 
     def test_stop_reports_the_crawler_wording_not_the_analysis_wording(self) -> None:
         gate = threading.Event()
         sidecar, holder = make(comments=[COMMENT_A], gate=gate)
         sidecar.handle({"id": "req-1", "method": "comments.start",
                         "params": {"input": "BV1xx411c7mD", "max_pages": 5}})
-        self.assertTrue(holder["crawler"].entered.wait(timeout=5))
+        crawler_of(holder)
 
         sidecar.handle({"id": "req-2", "method": "task.stop", "params": {}})
         gate.set()
@@ -439,30 +486,105 @@ class AnalysisBaseline(unittest.TestCase):
 
         sidecar._run_analysis({"source": "comments", "llm_config": {"api_key": "k"}})
 
-        self.assertFalse(sidecar.has("finished", "analysis"))
-        self.assertFalse(sidecar.has("error", "analysis"))
+        # cancelled -> log -> idle, in that order, and nothing else after.
+        self.assertEqual(sequence(sidecar), [
+            ("analysis.progress", None),
+            ("cancelled", "analysis"),
+            ("log", None),
+            ("progress", "analysis"),
+        ])
         self.assertEqual(sidecar.event("cancelled", "analysis")["mode"], "analysis")
-        logs = [frame["message"] for frame in sidecar.frames if frame.get("event") == "log"]
-        self.assertIn("分析任务已取消", logs)
-        self.assertEqual(sidecar.event("progress", "analysis")["status"], "idle")
+        self.assertEqual(sidecar.event("cancelled", "analysis")["message"], "分析已被取消")
+        self.assertEqual(sidecar.event("log")["message"], "分析任务已取消")
+        idle = sidecar.event("progress", "analysis")
+        self.assertEqual((idle["status"], idle["percent"]), ("idle", 100))
 
     def test_every_source_reaches_the_processor_with_both_datasets(self) -> None:
         # Source routing lives inside the processor, so the sidecar contract is
         # simply that it hands over both datasets plus the params untouched.
         # The migration must keep dynamics and all on this path.
-        for source in ("comments", "dynamics", "all"):
+        # "auto", a missing key and an unknown value must reach the processor
+        # untouched too: _normalize_source resolves them from the data, and the
+        # migration must not route on that inferred value.
+        for source in ("comments", "dynamics", "all", "auto", "not-a-source", None):
             with self.subTest(source=source):
                 processor = StubAnalysisProcessor(result=ANALYSIS_RESULT)
                 sidecar, _ = make(processor=processor)
                 sidecar._last_comments = [COMMENT_A]
                 sidecar._last_dynamics = [{"dynamic_id": "d1", "content": "一条动态"}]
 
-                sidecar._run_analysis({"source": source, "llm_config": {"api_key": "k"}})
+                request = {"llm_config": {"api_key": "k"}}
+                if source is not None:
+                    request["source"] = source
+                sidecar._run_analysis(request)
 
                 comments, dynamics, params = processor.calls[0]
                 self.assertEqual(len(comments), 1)
                 self.assertEqual(len(dynamics), 1)
-                self.assertEqual(params["source"], source)
+                if source is None:
+                    self.assertNotIn("source", params)
+                else:
+                    self.assertEqual(params["source"], source)
+                # Whatever the source, the sidecar never resolves it itself.
+                self.assertTrue(sidecar.has("finished", "analysis"))
+
+    def test_analysis_latest_returns_the_compact_display_shape(self) -> None:
+        # The RPC never returns the raw result: _display_analysis_result
+        # truncates every field and blanks report_markdown, while the raw result
+        # stays in memory for analysis.export. Both halves are pinned here.
+        raw_png = b"characterization-word-cloud-bytes"
+        processor = StubAnalysisProcessor(result={
+            **ANALYSIS_RESULT,
+            "word_counts": [{"name": "关键词", "value": 3}],
+            "notable_quotes": ["一条代表性评论"],
+            "word_cloud_image": "data:image/png;base64," + base64.b64encode(raw_png).decode("ascii"),
+        })
+        sidecar, _ = make(processor=processor)
+        sidecar._last_comments = [COMMENT_A]
+
+        original_root = Sidecar._analysis_asset_root
+        with tempfile.TemporaryDirectory() as temp_dir:
+            try:
+                Sidecar._analysis_asset_root = staticmethod(lambda: Path(temp_dir))
+                sidecar._run_analysis({"source": "comments", "llm_config": {"api_key": "k"}})
+                sidecar.handle({"id": "latest-1", "method": "analysis.latest", "params": {}})
+
+                responses = [frame for frame in sidecar.frames
+                             if frame.get("kind") == "response" and frame.get("id") == "latest-1"]
+                self.assertEqual(len(responses), 1)
+                self.assertTrue(responses[0]["ok"])
+                payload = responses[0]["result"]
+
+                self.assertEqual(sorted(payload), sorted([
+                    "summary", "summary_points", "overview", "sentiment_counts",
+                    "topic_counts", "word_counts", "risk_points", "insights",
+                    "notable_quotes", "time_series", "region_counts",
+                    "overseas_region_counts", "user_level_counts",
+                    "content_type_counts", "engagement_items", "deep_analysis",
+                    "report_markdown", "meta",
+                    "word_cloud_image", "word_cloud_image_path",
+                ]))
+                self.assertEqual(payload["report_markdown"], "")
+                self.assertEqual(payload["summary"], "总体偏正面")
+                self.assertTrue(payload["word_cloud_image"].startswith("data:image/png;base64,"))
+                image_path = Path(payload["word_cloud_image_path"])
+                self.assertTrue(image_path.is_file())
+                self.assertEqual(image_path.read_bytes(), raw_png)
+            finally:
+                Sidecar._analysis_asset_root = original_root
+
+        # The RPC payload is a projection; the raw result is untouched.
+        self.assertEqual(sidecar._last_analysis["report_markdown"], "# 报告")
+
+    def test_analysis_latest_without_a_result_answers_not_ok(self) -> None:
+        sidecar, _ = make()
+        sidecar.handle({"id": "latest-2", "method": "analysis.latest", "params": {}})
+
+        responses = [frame for frame in sidecar.frames
+                     if frame.get("kind") == "response" and frame.get("id") == "latest-2"]
+        self.assertEqual(len(responses), 1)
+        self.assertFalse(responses[0]["ok"])
+        self.assertIn("暂无分析结果", responses[0]["error"])
 
     def test_analysis_params_are_passed_through_verbatim(self) -> None:
         processor = StubAnalysisProcessor(result=ANALYSIS_RESULT)

--- a/tests/test_sidecar_characterization.py
+++ b/tests/test_sidecar_characterization.py
@@ -92,9 +92,15 @@ COMMENT_B = {
 class StubCrawler:
     """Same signature as CommentCrawler.crawl_comments, and it records the call.
 
-    stop() deliberately does *not* release the gate: the caller releases it, so
-    that the frames emitted by the task.stop handler are ordered against the
-    worker thread by the test rather than by the scheduler.
+    Two details are deliberately no kinder than the real crawler:
+
+    - stop() does not release the gate. The caller releases it, so the frames
+      emitted by the task.stop handler are ordered against the worker thread by
+      the test rather than by the scheduler.
+    - a stopped crawl returns only the page it had already fetched, the way
+      CommentCrawler returns what it accumulated once _stop_flag is set. A stub
+      that handed back the full list would make "finished carries the partial
+      data" an assertion about nothing.
     """
 
     def __init__(self, progress, comments=None, error=None, gate=None):
@@ -105,6 +111,7 @@ class StubCrawler:
         self.entered = threading.Event()
         self.stopped = False
         self.calls: list[dict] = []
+        self.fetched: list[dict] = []
 
     def stop(self):
         self.stopped = True
@@ -116,12 +123,15 @@ class StubCrawler:
             "max_pages": max_pages,
             "mode": mode,
         })
+        self.fetched = list(self.comments[:1])  # first page, before anyone can stop us
         self.entered.set()
         if self.gate is not None:
             self.gate.wait(timeout=5)
         if self.error is not None:
             raise self.error
-        return list(self.comments)
+        if not self.stopped:
+            self.fetched = list(self.comments)
+        return list(self.fetched)
 
 
 class StubAnalysisProcessor:
@@ -160,7 +170,15 @@ def make(comments=None, error=None, gate=None, processor=None):
     holder: dict = {}
 
     def factory(progress):
-        holder["crawler"] = StubCrawler(progress, comments=comments, error=error, gate=gate)
+        # DataProcessor.clean_comments fills defaults in place, so the crawler
+        # hands over copies: the fixtures above stay as written no matter which
+        # tests ran first.
+        holder["crawler"] = StubCrawler(
+            progress,
+            comments=[dict(comment) for comment in comments or []],
+            error=error,
+            gate=gate,
+        )
         return holder["crawler"]
 
     services = SidecarServices(
@@ -191,11 +209,33 @@ class CommentCrawlBaseline(unittest.TestCase):
 
         finished = sidecar.event("finished", "comments")
         self.assertEqual(finished["count"], 2)
+        # Today both frames carry the same dict; the assertion is here for the
+        # migration, where the two could be recomputed independently.
         self.assertEqual(finished["stats"], sidecar.event("stats", "comments")["stats"])
 
         idle = sidecar.event("progress", "comments")
         self.assertEqual(idle["status"], "idle")
         self.assertEqual(idle["percent"], 100)
+
+    def test_start_acknowledges_the_request_before_announcing_the_task(self) -> None:
+        # The frames _start_task emits before the worker runs are part of the
+        # contract too: the response lands first, then running(percent=0), then
+        # the startup log. taskState.ts drives the button state off that order.
+        sidecar, _ = make(comments=[COMMENT_A])
+        sidecar.handle({"id": "req-1", "method": "comments.start",
+                        "params": {"input": "BV1xx411c7mD", "max_pages": 1}})
+        drain(sidecar)
+
+        self.assertEqual(sidecar.frames[0], {"kind": "response", "id": "req-1", "ok": True})
+        self.assertEqual(
+            [frame["event"] for frame in sidecar.frames[1:]],
+            ["progress", "log", "stats", "finished", "progress"],
+        )
+        running = sidecar.frames[1]
+        self.assertEqual(running["status"], "running")
+        self.assertEqual(running["mode"], "comments")
+        self.assertEqual(running["percent"], 0)
+        self.assertEqual(sidecar.frames[2]["message"], "评论任务已启动")
 
     def test_stats_payload_carries_every_data_processor_field(self) -> None:
         # A migration that recomputes stats differently must not drop fields the
@@ -215,8 +255,12 @@ class CommentCrawlBaseline(unittest.TestCase):
         self.assertEqual(stats["total"], 2)
         self.assertEqual(stats["main_comments"], 1)
         self.assertEqual(stats["replies"], 1)
+        self.assertEqual(stats["total_likes"], 3)
+        self.assertEqual(stats["avg_likes"], 1.5)
+        self.assertEqual(stats["total_replies"], 1)  # counted over main comments only
         self.assertEqual(stats["ip_locations"], 1)
         self.assertEqual(stats["missing_ip_locations"], 1)
+        self.assertEqual(stats["ip_location_coverage"], 0.5)
 
     def test_empty_result_is_a_success_not_an_error(self) -> None:
         # AgentService raises CRAWL_FAILED here. The desktop path does not.
@@ -231,7 +275,12 @@ class CommentCrawlBaseline(unittest.TestCase):
 
     def test_failure_emits_error_without_finished_but_still_goes_idle(self) -> None:
         sidecar, _ = make(error=RuntimeError("接口返回 412"))
-        sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
+        # The traceback goes to the sidecar logger, i.e. to stderr, never into
+        # the protocol stream on stdout. Capturing it pins that and keeps the
+        # test output clean.
+        with self.assertLogs("sidecar", level="ERROR") as captured:
+            sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
+        self.assertIn("comments task failed", "\n".join(captured.output))
 
         self.assertFalse(sidecar.has("finished", "comments"))
         error = sidecar.event("error", "comments")
@@ -285,7 +334,9 @@ class CommentStopBaseline(unittest.TestCase):
         # finished frame is legitimate, not a stale one -- see conflict 9 in
         # docs/SIDECAR_MIGRATION.md.
         gate = threading.Event()
-        sidecar, holder = make(comments=[COMMENT_A], gate=gate)
+        # Two comments are on offer but the crawler is stopped after the first
+        # page, so finished carries one of them: partial, and still finished.
+        sidecar, holder = make(comments=[COMMENT_A, COMMENT_B], gate=gate)
 
         sidecar.handle({"id": "req-1", "method": "comments.start",
                         "params": {"input": "BV1xx411c7mD", "max_pages": 5}})
@@ -296,12 +347,15 @@ class CommentStopBaseline(unittest.TestCase):
         # test ordered them, not because it won a race against the worker.
         sidecar.handle({"id": "req-2", "method": "task.stop", "params": {}})
         self.assertTrue(holder["crawler"].stopped)
+        # Stopping a crawl must not arm the analysis cancel flag (v3.1.1).
+        self.assertFalse(sidecar._analysis_cancel.is_set())
         gate.set()
         drain(sidecar)
 
         self.assertTrue(sidecar.has("finished", "comments"),
                         "stopping a comment crawl still emits finished today")
         self.assertEqual(sidecar.event("finished", "comments")["count"], 1)
+        self.assertEqual([row["comment_id"] for row in sidecar._last_comments], [1])
 
         statuses = [frame["status"] for frame in sidecar.frames
                     if frame.get("event") == "progress" and frame.get("mode") == "comments"]

--- a/tests/test_sidecar_characterization.py
+++ b/tests/test_sidecar_characterization.py
@@ -118,6 +118,11 @@ class StubCrawler:
 
     def stop(self):
         self.stopped = True
+        # CommentCrawler.stop() calls _log("正在停止爬取..."), which reaches the
+        # sidecar's progress callback and becomes a log frame. A silent stub
+        # would let the migration drop that frame unnoticed, so the stub is as
+        # loud as the real thing.
+        self.progress("正在停止爬取...")
 
     def crawl_comments(self, url_or_id, include_replies=True, max_pages=100, mode=3):
         self.calls.append({
@@ -167,6 +172,31 @@ ANALYSIS_RESULT = {
     "report_markdown": "# 报告",
     "meta": {"analyzed_records": 7, "total_records": 9},
 }
+
+
+# DataProcessor.get_statistics output for the fixtures above, recorded rather
+# than hand-written: an assertion on a stats dict someone guessed is worthless.
+FULL_STATS = {
+    "total": 2, "main_comments": 1, "replies": 1, "total_likes": 3, "avg_likes": 1.5,
+    "total_replies": 1, "ip_locations": 1, "missing_ip_locations": 1,
+    "ip_location_coverage": 0.5,
+}
+
+EMPTY_STATS = {
+    "total": 0, "main_comments": 0, "replies": 0, "total_likes": 0, "avg_likes": 0,
+    "total_replies": 0, "ip_locations": 0, "missing_ip_locations": 0,
+    "ip_location_coverage": 0,
+}
+
+# Only COMMENT_A survives a stop after the first page.
+PARTIAL_STATS = {
+    "total": 1, "main_comments": 1, "replies": 0, "total_likes": 3, "avg_likes": 3.0,
+    "total_replies": 1, "ip_locations": 1, "missing_ip_locations": 0,
+    "ip_location_coverage": 1.0,
+}
+
+WORD_CLOUD_BYTES = b"characterization-word-cloud-bytes"
+WORD_CLOUD_DATA_URL = "data:image/png;base64,Y2hhcmFjdGVyaXphdGlvbi13b3JkLWNsb3VkLWJ5dGVz"
 
 
 def make(comments=None, error=None, gate=None, processor=None):
@@ -272,14 +302,7 @@ class CommentCrawlBaseline(unittest.TestCase):
         sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
 
         stats = sidecar.event("stats", "comments")["stats"]
-        self.assertEqual(
-            sorted(stats),
-            sorted([
-                "total", "main_comments", "replies", "total_likes", "avg_likes",
-                "total_replies", "ip_locations", "missing_ip_locations",
-                "ip_location_coverage",
-            ]),
-        )
+        self.assertEqual(stats, FULL_STATS)
         self.assertEqual(stats["total"], 2)
         self.assertEqual(stats["main_comments"], 1)
         self.assertEqual(stats["replies"], 1)
@@ -300,7 +323,8 @@ class CommentCrawlBaseline(unittest.TestCase):
                          [("stats", "comments"), ("finished", "comments"), ("progress", "comments")])
         finished = sidecar.event("finished", "comments")
         self.assertEqual(finished["count"], 0)
-        self.assertEqual(finished["stats"]["total"], 0)
+        self.assertEqual(finished["stats"], EMPTY_STATS)
+        self.assertEqual(sidecar.event("stats", "comments")["stats"], EMPTY_STATS)
         idle = sidecar.event("progress", "comments")
         self.assertEqual((idle["status"], idle["percent"]), ("idle", 100))
 
@@ -316,9 +340,10 @@ class CommentCrawlBaseline(unittest.TestCase):
         # No stats frame on this path, and no finished -- just error then idle.
         self.assertEqual(sequence(sidecar),
                          [("error", "comments"), ("progress", "comments")])
-        error = sidecar.event("error", "comments")
-        self.assertEqual(error["mode"], "comments")
-        self.assertIn("412", error["message"])
+        self.assertEqual(
+            sidecar.event("error", "comments"),
+            {"kind": "event", "event": "error", "mode": "comments", "message": "接口返回 412"},
+        )
         idle = sidecar.event("progress", "comments")
         self.assertEqual((idle["status"], idle["percent"]), ("idle", 100))
 
@@ -388,7 +413,10 @@ class CommentStopBaseline(unittest.TestCase):
 
         self.assertTrue(sidecar.has("finished", "comments"),
                         "stopping a comment crawl still emits finished today")
-        self.assertEqual(sidecar.event("finished", "comments")["count"], 1)
+        finished = sidecar.event("finished", "comments")
+        self.assertEqual(finished["count"], 1)
+        self.assertEqual(finished["stats"], PARTIAL_STATS)
+        self.assertEqual(sidecar.event("stats", "comments")["stats"], PARTIAL_STATS)
         self.assertEqual([row["comment_id"] for row in sidecar._last_comments], [1])
 
         # Full sequence, both threads: start frames, the stop frames emitted on
@@ -396,12 +424,17 @@ class CommentStopBaseline(unittest.TestCase):
         self.assertEqual(sequence(sidecar), [
             ("progress", "comments"),   # running, 0
             ("log", None),              # 评论任务已启动
-            ("log", None),              # 正在停止爬取任务...
+            ("log", None),              # 正在停止爬取...      (from crawler.stop)
+            ("log", None),              # 正在停止爬取任务...  (from the task.stop handler)
             ("progress", "comments"),   # stopping, 0
             ("stats", "comments"),
             ("finished", "comments"),
             ("progress", "comments"),   # idle, 100
         ])
+        self.assertEqual(
+            [frame["message"] for frame in sidecar.frames if frame.get("event") == "log"],
+            ["评论任务已启动", "正在停止爬取...", "正在停止爬取任务..."],
+        )
         progress_frames = [frame for frame in sidecar.frames
                            if frame.get("event") == "progress" and frame.get("mode") == "comments"]
         self.assertEqual(
@@ -493,8 +526,14 @@ class AnalysisBaseline(unittest.TestCase):
             ("log", None),
             ("progress", "analysis"),
         ])
-        self.assertEqual(sidecar.event("cancelled", "analysis")["mode"], "analysis")
-        self.assertEqual(sidecar.event("cancelled", "analysis")["message"], "分析已被取消")
+        self.assertEqual(
+            sidecar.event("analysis.progress"),
+            {"kind": "event", "event": "analysis.progress", "message": "正在调用 LLM", "percent": 50},
+        )
+        self.assertEqual(
+            sidecar.event("cancelled", "analysis"),
+            {"kind": "event", "event": "cancelled", "mode": "analysis", "message": "分析已被取消"},
+        )
         self.assertEqual(sidecar.event("log")["message"], "分析任务已取消")
         idle = sidecar.event("progress", "analysis")
         self.assertEqual((idle["status"], idle["percent"]), ("idle", 100))
@@ -532,7 +571,7 @@ class AnalysisBaseline(unittest.TestCase):
         # The RPC never returns the raw result: _display_analysis_result
         # truncates every field and blanks report_markdown, while the raw result
         # stays in memory for analysis.export. Both halves are pinned here.
-        raw_png = b"characterization-word-cloud-bytes"
+        raw_png = WORD_CLOUD_BYTES
         processor = StubAnalysisProcessor(result={
             **ANALYSIS_RESULT,
             "word_counts": [{"name": "关键词", "value": 3}],
@@ -555,26 +594,47 @@ class AnalysisBaseline(unittest.TestCase):
                 self.assertTrue(responses[0]["ok"])
                 payload = responses[0]["result"]
 
-                self.assertEqual(sorted(payload), sorted([
-                    "summary", "summary_points", "overview", "sentiment_counts",
-                    "topic_counts", "word_counts", "risk_points", "insights",
-                    "notable_quotes", "time_series", "region_counts",
-                    "overseas_region_counts", "user_level_counts",
-                    "content_type_counts", "engagement_items", "deep_analysis",
-                    "report_markdown", "meta",
-                    "word_cloud_image", "word_cloud_image_path",
-                ]))
-                self.assertEqual(payload["report_markdown"], "")
-                self.assertEqual(payload["summary"], "总体偏正面")
-                self.assertTrue(payload["word_cloud_image"].startswith("data:image/png;base64,"))
-                image_path = Path(payload["word_cloud_image_path"])
+                # The whole payload, value by value. Only the asset path is
+                # dynamic, so it is popped and checked separately.
+                image_path = Path(payload.pop("word_cloud_image_path"))
+                self.assertEqual(payload, {
+                    "summary": "总体偏正面",
+                    "summary_points": [],
+                    "overview": {
+                        "total_records": 9, "analyzed_records": 7, "risk_count": 1,
+                        "ip_locations": 5, "missing_ip_locations": 4,
+                    },
+                    "sentiment_counts": [],
+                    "topic_counts": [],
+                    "word_counts": [{"name": "关键词", "value": 3}],
+                    "risk_points": [],
+                    "insights": [],
+                    "notable_quotes": ["一条代表性评论"],
+                    "time_series": [],
+                    "region_counts": [],
+                    "overseas_region_counts": [],
+                    "user_level_counts": [],
+                    "content_type_counts": [],
+                    "engagement_items": [],
+                    "deep_analysis": {"sociology": "", "psychology": "", "philosophy": ""},
+                    "report_markdown": "",
+                    "meta": {"analyzed_records": 7, "total_records": 9},
+                    "word_cloud_image": WORD_CLOUD_DATA_URL,
+                })
                 self.assertTrue(image_path.is_file())
                 self.assertEqual(image_path.read_bytes(), raw_png)
             finally:
                 Sidecar._analysis_asset_root = original_root
 
-        # The RPC payload is a projection; the raw result is untouched.
-        self.assertEqual(sidecar._last_analysis["report_markdown"], "# 报告")
+        # The RPC payload is a projection; the raw result keeps everything the
+        # display shape dropped or rewrote.
+        raw = sidecar._last_analysis
+        self.assertEqual(raw["report_markdown"], "# 报告")
+        self.assertEqual(raw["summary"], "总体偏正面")
+        self.assertEqual(raw["word_counts"], [{"name": "关键词", "value": 3}])
+        self.assertEqual(raw["notable_quotes"], ["一条代表性评论"])
+        self.assertEqual(raw["meta"], {"analyzed_records": 7, "total_records": 9})
+        self.assertTrue(raw["word_cloud_image"].startswith("data:image/png;base64,"))
 
     def test_analysis_latest_without_a_result_answers_not_ok(self) -> None:
         sidecar, _ = make()

--- a/tests/test_sidecar_characterization.py
+++ b/tests/test_sidecar_characterization.py
@@ -10,7 +10,8 @@ before the migration rather than after:
 - an empty crawl result is a success here (finished(count=0)), not a failure;
 - stopping a comment crawl still emits finished with whatever was fetched,
   because _run_comments performs no cancellation check at all;
-- cancelling analysis emits cancelled and never finished.
+- cancelling analysis emits cancelled and never finished;
+- the crawl request's own max_pages is forwarded, with no ceiling of 50.
 
 If a change makes one of these fail, that is a behaviour change and belongs in
 its own PR with its own justification -- not in the migration.
@@ -89,6 +90,13 @@ COMMENT_B = {
 
 
 class StubCrawler:
+    """Same signature as CommentCrawler.crawl_comments, and it records the call.
+
+    stop() deliberately does *not* release the gate: the caller releases it, so
+    that the frames emitted by the task.stop handler are ordered against the
+    worker thread by the test rather than by the scheduler.
+    """
+
     def __init__(self, progress, comments=None, error=None, gate=None):
         self.progress = progress
         self.comments = [] if comments is None else comments
@@ -96,13 +104,18 @@ class StubCrawler:
         self.gate = gate
         self.entered = threading.Event()
         self.stopped = False
+        self.calls: list[dict] = []
 
     def stop(self):
         self.stopped = True
-        if self.gate is not None:
-            self.gate.set()
 
     def crawl_comments(self, url_or_id, include_replies=True, max_pages=100, mode=3):
+        self.calls.append({
+            "url_or_id": url_or_id,
+            "include_replies": include_replies,
+            "max_pages": max_pages,
+            "mode": mode,
+        })
         self.entered.set()
         if self.gate is not None:
             self.gate.wait(timeout=5)
@@ -126,11 +139,20 @@ class StubAnalysisProcessor:
         return dict(self.result or {})
 
 
+# analyzed_records is deliberately different from the number of comments held in
+# _last_comments, so an assertion on finished.count pins where that number comes
+# from. overview carries the keys the desktop stat tiles read for analysis mode.
 ANALYSIS_RESULT = {
     "summary": "总体偏正面",
-    "overview": {"total": 2},
+    "overview": {
+        "total_records": 9,
+        "analyzed_records": 7,
+        "risk_count": 1,
+        "ip_locations": 5,
+        "missing_ip_locations": 4,
+    },
     "report_markdown": "# 报告",
-    "meta": {"analyzed_records": 2, "total_records": 2},
+    "meta": {"analyzed_records": 7, "total_records": 9},
 }
 
 
@@ -224,6 +246,37 @@ class CommentCrawlBaseline(unittest.TestCase):
         self.assertEqual(sidecar._last_comment_context.get("label"), "视频评论")
         self.assertEqual(sidecar._last_comment_context.get("bvid"), "BV1xx411c7mD")
 
+    def test_request_params_reach_the_crawler_verbatim(self) -> None:
+        # Conflicts 1 and 2: AgentService clamps max_pages to its own ceiling of
+        # 50 and decides the rest itself. The desktop path forwards whatever the
+        # UI sent, and renames sort_mode to the crawler's mode.
+        sidecar, holder = make(comments=[COMMENT_A])
+        sidecar._run_comments({
+            "input": "BV1xx411c7mD",
+            "max_pages": 80,
+            "include_replies": False,
+            "sort_mode": 2,
+        })
+
+        self.assertEqual(holder["crawler"].calls, [{
+            "url_or_id": "BV1xx411c7mD",
+            "include_replies": False,
+            "max_pages": 80,
+            "mode": 2,
+        }])
+
+    def test_absent_params_fall_back_to_the_desktop_defaults(self) -> None:
+        # 100 pages, not AgentService's MAX_PAGES_CEILING.
+        sidecar, holder = make(comments=[COMMENT_A])
+        sidecar._run_comments({"input": "BV1xx411c7mD"})
+
+        self.assertEqual(holder["crawler"].calls, [{
+            "url_or_id": "BV1xx411c7mD",
+            "include_replies": True,
+            "max_pages": 100,
+            "mode": 3,
+        }])
+
 
 class CommentStopBaseline(unittest.TestCase):
     def test_stopping_a_crawl_still_finishes_with_the_partial_data(self) -> None:
@@ -238,10 +291,14 @@ class CommentStopBaseline(unittest.TestCase):
                         "params": {"input": "BV1xx411c7mD", "max_pages": 5}})
         self.assertTrue(holder["crawler"].entered.wait(timeout=5))
 
+        # task.stop emits its frames on the calling thread, so the crawler is
+        # released only afterwards: "stopping" then precedes "idle" because the
+        # test ordered them, not because it won a race against the worker.
         sidecar.handle({"id": "req-2", "method": "task.stop", "params": {}})
+        self.assertTrue(holder["crawler"].stopped)
+        gate.set()
         drain(sidecar)
 
-        self.assertTrue(holder["crawler"].stopped)
         self.assertTrue(sidecar.has("finished", "comments"),
                         "stopping a comment crawl still emits finished today")
         self.assertEqual(sidecar.event("finished", "comments")["count"], 1)
@@ -259,6 +316,7 @@ class CommentStopBaseline(unittest.TestCase):
         self.assertTrue(holder["crawler"].entered.wait(timeout=5))
 
         sidecar.handle({"id": "req-2", "method": "task.stop", "params": {}})
+        gate.set()
         drain(sidecar)
 
         logs = [frame["message"] for frame in sidecar.frames if frame.get("event") == "log"]
@@ -275,13 +333,39 @@ class AnalysisBaseline(unittest.TestCase):
         sidecar._run_analysis({"source": "comments", "llm_config": {"api_key": "k"}})
 
         finished = sidecar.event("finished", "analysis")
-        self.assertEqual(finished["count"], 2)
+        # count is meta.analyzed_records, not how many comments were held: the
+        # two differ here so that a migration cannot swap one for the other.
+        self.assertEqual(len(sidecar._last_comments), 2)
+        self.assertEqual(finished["count"], 7)
         # The RPC payload is the compact display shape, not the raw result.
         self.assertEqual(finished["result"]["report_markdown"], "")
         self.assertEqual(finished["result"]["summary"], "总体偏正面")
         # ...while the raw result stays in memory for analysis.export.
         self.assertEqual(sidecar._last_analysis["report_markdown"], "# 报告")
         self.assertEqual(sidecar.event("progress", "analysis")["status"], "idle")
+
+    def test_finished_stats_carry_the_overview_fields_the_ui_reads(self) -> None:
+        # The analysis stat tiles read total_records / analyzed_records /
+        # risk_count / ip_locations / missing_ip_locations off statsByMode
+        # (desktop/src/App.tsx), fed by both finished.stats and
+        # finished.result.overview. Conflict 6 -- RunStore.save_analysis
+        # reshapes the stored result -- is exactly how these could drift.
+        expected = {
+            "total_records": 9,
+            "analyzed_records": 7,
+            "risk_count": 1,
+            "ip_locations": 5,
+            "missing_ip_locations": 4,
+        }
+        sidecar, _ = make(processor=StubAnalysisProcessor(result=ANALYSIS_RESULT))
+        sidecar._last_comments = [COMMENT_A, COMMENT_B]
+
+        sidecar._run_analysis({"source": "comments", "llm_config": {"api_key": "k"}})
+
+        finished = sidecar.event("finished", "analysis")
+        self.assertEqual(finished["stats"], expected)
+        self.assertEqual(finished["result"]["overview"], expected)
+        self.assertEqual(finished["result"]["meta"], {"analyzed_records": 7, "total_records": 9})
 
     def test_progress_percentages_are_forwarded_unscaled(self) -> None:
         # AgentService rescales analysis progress into 70-95; the desktop

--- a/tests/test_sidecar_characterization.py
+++ b/tests/test_sidecar_characterization.py
@@ -1,0 +1,349 @@
+"""
+Behaviour baseline for the v3.3.0 sidecar migration (docs/SIDECAR_MIGRATION.md).
+
+These tests do not describe behaviour anyone designed on purpose -- they pin
+down what backend/sidecar.py does *today*, so that moving the orchestration onto
+AgentService cannot change it by accident. Several of the pinned behaviours
+differ from AgentService's own semantics, which is exactly why they are written
+before the migration rather than after:
+
+- an empty crawl result is a success here (finished(count=0)), not a failure;
+- stopping a comment crawl still emits finished with whatever was fetched,
+  because _run_comments performs no cancellation check at all;
+- cancelling analysis emits cancelled and never finished.
+
+If a change makes one of these fail, that is a behaviour change and belongs in
+its own PR with its own justification -- not in the migration.
+"""
+import threading
+import unittest
+
+from backend.sidecar import Sidecar, SidecarServices
+from src.processor.analysis_processor import AnalysisCancelled
+
+
+class RecordingSidecar(Sidecar):
+    """Captures every protocol frame instead of writing it to stdout."""
+
+    def __init__(self, services: SidecarServices | None = None) -> None:
+        super().__init__(services=services)
+        self.frames: list[dict] = []
+
+    def _send(self, payload: dict) -> None:
+        self.frames.append(payload)
+
+    # -- helpers ---------------------------------------------------------
+    def events(self, mode: str | None = None) -> list[str]:
+        return [
+            frame["event"]
+            for frame in self.frames
+            if frame.get("kind") == "event" and (mode is None or frame.get("mode") == mode)
+        ]
+
+    def event(self, name: str, mode: str | None = None) -> dict:
+        matches = [
+            frame
+            for frame in self.frames
+            if frame.get("kind") == "event"
+            and frame.get("event") == name
+            and (mode is None or frame.get("mode") == mode)
+        ]
+        if not matches:
+            raise AssertionError(f"no {name!r} event (mode={mode!r}) in {self.events()}")
+        return matches[-1]
+
+    def has(self, name: str, mode: str | None = None) -> bool:
+        return any(
+            frame.get("kind") == "event"
+            and frame.get("event") == name
+            and (mode is None or frame.get("mode") == mode)
+            for frame in self.frames
+        )
+
+
+COMMENT_A = {
+    "comment_id": 1,
+    "root_id": 0,
+    "is_reply": False,
+    "username": "用户A",
+    "user_level": 5,
+    "content": "第一条评论",
+    "like_count": 3,
+    "reply_count": 1,
+    "ctime": 1735660800,
+    "ctime_text": "2025-01-01 00:00:00",
+    "ip_location": "广东",
+}
+
+COMMENT_B = {
+    **COMMENT_A,
+    "comment_id": 2,
+    "root_id": 1,
+    "is_reply": True,
+    "username": "用户B",
+    "content": "第二条评论",
+    "like_count": 0,
+    "reply_count": 0,
+    "ip_location": "",
+}
+
+
+class StubCrawler:
+    def __init__(self, progress, comments=None, error=None, gate=None):
+        self.progress = progress
+        self.comments = [] if comments is None else comments
+        self.error = error
+        self.gate = gate
+        self.entered = threading.Event()
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+        if self.gate is not None:
+            self.gate.set()
+
+    def crawl_comments(self, url_or_id, include_replies=True, max_pages=100, mode=3):
+        self.entered.set()
+        if self.gate is not None:
+            self.gate.wait(timeout=5)
+        if self.error is not None:
+            raise self.error
+        return list(self.comments)
+
+
+class StubAnalysisProcessor:
+    def __init__(self, result=None, error=None):
+        self.result = result
+        self.error = error
+        self.calls: list[tuple] = []
+
+    def analyze(self, comments, dynamics, params, progress=None, cancel_event=None):
+        self.calls.append((list(comments), list(dynamics), dict(params)))
+        if progress:
+            progress("正在调用 LLM", 50)
+        if self.error is not None:
+            raise self.error
+        return dict(self.result or {})
+
+
+ANALYSIS_RESULT = {
+    "summary": "总体偏正面",
+    "overview": {"total": 2},
+    "report_markdown": "# 报告",
+    "meta": {"analyzed_records": 2, "total_records": 2},
+}
+
+
+def make(comments=None, error=None, gate=None, processor=None):
+    holder: dict = {}
+
+    def factory(progress):
+        holder["crawler"] = StubCrawler(progress, comments=comments, error=error, gate=gate)
+        return holder["crawler"]
+
+    services = SidecarServices(
+        api=object(),
+        comment_crawler_factory=factory,
+        analysis_processor=processor or StubAnalysisProcessor(result=ANALYSIS_RESULT),
+    )
+    return RecordingSidecar(services), holder
+
+
+def drain(sidecar: RecordingSidecar, timeout: float = 5.0) -> None:
+    thread = sidecar._active_thread
+    if thread is not None:
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            raise AssertionError("sidecar task thread did not finish")
+
+
+class CommentCrawlBaseline(unittest.TestCase):
+    def test_success_emits_stats_then_finished_then_idle(self) -> None:
+        sidecar, _ = make(comments=[COMMENT_A, COMMENT_B])
+        sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
+
+        self.assertEqual(
+            [event for event in sidecar.events("comments") if event != "log"],
+            ["stats", "finished", "progress"],
+        )
+
+        finished = sidecar.event("finished", "comments")
+        self.assertEqual(finished["count"], 2)
+        self.assertEqual(finished["stats"], sidecar.event("stats", "comments")["stats"])
+
+        idle = sidecar.event("progress", "comments")
+        self.assertEqual(idle["status"], "idle")
+        self.assertEqual(idle["percent"], 100)
+
+    def test_stats_payload_carries_every_data_processor_field(self) -> None:
+        # A migration that recomputes stats differently must not drop fields the
+        # UI reads; assert each one rather than just `total`.
+        sidecar, _ = make(comments=[COMMENT_A, COMMENT_B])
+        sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
+
+        stats = sidecar.event("stats", "comments")["stats"]
+        self.assertEqual(
+            sorted(stats),
+            sorted([
+                "total", "main_comments", "replies", "total_likes", "avg_likes",
+                "total_replies", "ip_locations", "missing_ip_locations",
+                "ip_location_coverage",
+            ]),
+        )
+        self.assertEqual(stats["total"], 2)
+        self.assertEqual(stats["main_comments"], 1)
+        self.assertEqual(stats["replies"], 1)
+        self.assertEqual(stats["ip_locations"], 1)
+        self.assertEqual(stats["missing_ip_locations"], 1)
+
+    def test_empty_result_is_a_success_not_an_error(self) -> None:
+        # AgentService raises CRAWL_FAILED here. The desktop path does not.
+        sidecar, _ = make(comments=[])
+        sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
+
+        self.assertFalse(sidecar.has("error", "comments"))
+        finished = sidecar.event("finished", "comments")
+        self.assertEqual(finished["count"], 0)
+        self.assertEqual(finished["stats"]["total"], 0)
+        self.assertEqual(sidecar.event("progress", "comments")["status"], "idle")
+
+    def test_failure_emits_error_without_finished_but_still_goes_idle(self) -> None:
+        sidecar, _ = make(error=RuntimeError("接口返回 412"))
+        sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
+
+        self.assertFalse(sidecar.has("finished", "comments"))
+        error = sidecar.event("error", "comments")
+        self.assertEqual(error["mode"], "comments")
+        self.assertIn("412", error["message"])
+        self.assertEqual(sidecar.event("progress", "comments")["status"], "idle")
+
+    def test_comment_context_is_recorded_for_asset_naming(self) -> None:
+        sidecar, _ = make(comments=[COMMENT_A])
+        sidecar._run_comments({"input": "BV1xx411c7mD", "max_pages": 1})
+
+        self.assertEqual(sidecar._last_comment_context.get("label"), "视频评论")
+        self.assertEqual(sidecar._last_comment_context.get("bvid"), "BV1xx411c7mD")
+
+
+class CommentStopBaseline(unittest.TestCase):
+    def test_stopping_a_crawl_still_finishes_with_the_partial_data(self) -> None:
+        # _run_comments has no cancellation check: crawler.stop() only makes the
+        # crawler return early, and the handler carries on to finished(). This
+        # finished frame is legitimate, not a stale one -- see conflict 9 in
+        # docs/SIDECAR_MIGRATION.md.
+        gate = threading.Event()
+        sidecar, holder = make(comments=[COMMENT_A], gate=gate)
+
+        sidecar.handle({"id": "req-1", "method": "comments.start",
+                        "params": {"input": "BV1xx411c7mD", "max_pages": 5}})
+        self.assertTrue(holder["crawler"].entered.wait(timeout=5))
+
+        sidecar.handle({"id": "req-2", "method": "task.stop", "params": {}})
+        drain(sidecar)
+
+        self.assertTrue(holder["crawler"].stopped)
+        self.assertTrue(sidecar.has("finished", "comments"),
+                        "stopping a comment crawl still emits finished today")
+        self.assertEqual(sidecar.event("finished", "comments")["count"], 1)
+
+        statuses = [frame["status"] for frame in sidecar.frames
+                    if frame.get("event") == "progress" and frame.get("mode") == "comments"]
+        self.assertIn("stopping", statuses)
+        self.assertEqual(statuses[-1], "idle")
+
+    def test_stop_reports_the_crawler_wording_not_the_analysis_wording(self) -> None:
+        gate = threading.Event()
+        sidecar, holder = make(comments=[COMMENT_A], gate=gate)
+        sidecar.handle({"id": "req-1", "method": "comments.start",
+                        "params": {"input": "BV1xx411c7mD", "max_pages": 5}})
+        self.assertTrue(holder["crawler"].entered.wait(timeout=5))
+
+        sidecar.handle({"id": "req-2", "method": "task.stop", "params": {}})
+        drain(sidecar)
+
+        logs = [frame["message"] for frame in sidecar.frames if frame.get("event") == "log"]
+        self.assertIn("正在停止爬取任务...", logs)
+        self.assertNotIn("正在停止分析任务...", logs)
+
+
+class AnalysisBaseline(unittest.TestCase):
+    def test_success_emits_finished_with_the_display_payload(self) -> None:
+        processor = StubAnalysisProcessor(result=ANALYSIS_RESULT)
+        sidecar, _ = make(processor=processor)
+        sidecar._last_comments = [COMMENT_A, COMMENT_B]
+
+        sidecar._run_analysis({"source": "comments", "llm_config": {"api_key": "k"}})
+
+        finished = sidecar.event("finished", "analysis")
+        self.assertEqual(finished["count"], 2)
+        # The RPC payload is the compact display shape, not the raw result.
+        self.assertEqual(finished["result"]["report_markdown"], "")
+        self.assertEqual(finished["result"]["summary"], "总体偏正面")
+        # ...while the raw result stays in memory for analysis.export.
+        self.assertEqual(sidecar._last_analysis["report_markdown"], "# 报告")
+        self.assertEqual(sidecar.event("progress", "analysis")["status"], "idle")
+
+    def test_progress_percentages_are_forwarded_unscaled(self) -> None:
+        # AgentService rescales analysis progress into 70-95; the desktop
+        # contract is the processor's own 0-100.
+        sidecar, _ = make()
+        sidecar._last_comments = [COMMENT_A]
+        sidecar._run_analysis({"source": "comments", "llm_config": {"api_key": "k"}})
+
+        percents = [frame["percent"] for frame in sidecar.frames
+                    if frame.get("event") == "analysis.progress"]
+        self.assertEqual(percents, [50])
+
+    def test_cancel_emits_cancelled_and_never_finished(self) -> None:
+        processor = StubAnalysisProcessor(error=AnalysisCancelled("分析已被取消"))
+        sidecar, _ = make(processor=processor)
+        sidecar._last_comments = [COMMENT_A]
+
+        sidecar._run_analysis({"source": "comments", "llm_config": {"api_key": "k"}})
+
+        self.assertFalse(sidecar.has("finished", "analysis"))
+        self.assertFalse(sidecar.has("error", "analysis"))
+        self.assertEqual(sidecar.event("cancelled", "analysis")["mode"], "analysis")
+        logs = [frame["message"] for frame in sidecar.frames if frame.get("event") == "log"]
+        self.assertIn("分析任务已取消", logs)
+        self.assertEqual(sidecar.event("progress", "analysis")["status"], "idle")
+
+    def test_every_source_reaches_the_processor_with_both_datasets(self) -> None:
+        # Source routing lives inside the processor, so the sidecar contract is
+        # simply that it hands over both datasets plus the params untouched.
+        # The migration must keep dynamics and all on this path.
+        for source in ("comments", "dynamics", "all"):
+            with self.subTest(source=source):
+                processor = StubAnalysisProcessor(result=ANALYSIS_RESULT)
+                sidecar, _ = make(processor=processor)
+                sidecar._last_comments = [COMMENT_A]
+                sidecar._last_dynamics = [{"dynamic_id": "d1", "content": "一条动态"}]
+
+                sidecar._run_analysis({"source": source, "llm_config": {"api_key": "k"}})
+
+                comments, dynamics, params = processor.calls[0]
+                self.assertEqual(len(comments), 1)
+                self.assertEqual(len(dynamics), 1)
+                self.assertEqual(params["source"], source)
+
+    def test_analysis_params_are_passed_through_verbatim(self) -> None:
+        processor = StubAnalysisProcessor(result=ANALYSIS_RESULT)
+        sidecar, _ = make(processor=processor)
+        sidecar._last_comments = [COMMENT_A]
+
+        sent = {
+            "source": "comments",
+            "sample_size": 123,
+            "batch_size": 45,
+            "chart_keys": ["word_cloud", "topic_ranking"],
+            "llm_config": {"api_key": "k", "base_url": "https://x/v1", "model": "m"},
+        }
+        sidecar._run_analysis(dict(sent))
+
+        _, _, params = processor.calls[0]
+        for key, value in sent.items():
+            self.assertEqual(params[key], value, f"{key} was not passed through")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[docs/SIDECAR_MIGRATION.md](https://github.com/Yi-luo-hua/BilibiliCrawler/blob/main/docs/SIDECAR_MIGRATION.md) 实施顺序的**第 1 步**：先把旧 Sidecar 的当前行为钉住，再动编排。

**本 PR 不含任何生产代码改动**——`backend/` 与 `src/` 一行没动，只新增一个测试文件。

## 为什么先写这个

有三条行为与 `AgentService` 的语义**不同**，如果先接线再补测试，就会在没人察觉的情况下被改掉：

| 行为 | 旧 Sidecar（本 PR 钉住的） | AgentService |
|---|---|---|
| 空结果 | `finished(count=0)`，不发 `error` | 抛 `CRAWL_FAILED` |
| 评论爬取停止 | 仍发 `finished`，带已抓到的部分数据 | 判定 `cancelled` |
| 分析进度 | processor 原始 0–100 | 重标到 70–95 |

第二条的根因是 `_run_comments` **完全没有取消检查**：`crawler.stop()` 只让 `crawl_comments` 早返回，处理照常走到 `finished`。这个 `finished` 是合法的，不是陈旧帧。

## 18 项基线钉住了什么

**逐帧**——四条路径（成功 / 空结果 / 异常 / 停止）都断言**精确的 `(event, mode)` 序列**，多一帧、错序、`idle.percent` 不是 100 都会红。停止路径额外断言 progress 的 `(status, percent)` 顺序为 `[("running",0), ("stopping",0), ("idle",100)]`，以及三条 log 消息的顺序。

**逐值**——`stats` 九个字段整体比对（常量取自 `DataProcessor` 实测，不是手写猜的）；`error` 帧整体比对；分析取消把前置的 `analysis.progress` 也钉住 `message` 与 `percent`。

**`analysis.latest` 契约**——真正调用该 RPC，把返回值**作为一个完整字典**比对（只有动态的 asset 路径单独处理）：20 个键、`report_markdown` 为空串、`word_counts` / `notable_quotes` / `deep_analysis` / `overview` / `meta` 的值、`word_cloud_image` 的 data URL，以及 `word_cloud_image_path` 指向的真实文件字节。同时确认 `_last_analysis` 保留原始 markdown 等被 display 丢弃或改写的内容。另有一条：无结果时返回 `ok: false` + `暂无分析结果`。

**来源路由**——`comments` / `dynamics` / `all` / `auto` / 非法值 / **缺失 key** 六种，全部必须原样抵达 processor。`_normalize_source` 会按数据把它们推断成某个具体值，迁移时不能依赖这个推断来路由。

**其他**——`_last_comment_context`（词云 asset 目录命名依赖它）、请求参数逐键透传（`max_pages` 无 50 上限、`sort_mode` → `mode` 改名）、缺省参数回落到桌面默认值（100 页而非 AgentService 的 50）。

## 替身不比真实对象宽容

- `StubCrawler.stop()` 会像真的 `CommentCrawler.stop()` 一样发出「正在停止爬取...」日志，否则迁移丢掉这一帧不会被发现。
- 被停止的爬虫只返回第一页，而不是完整列表，否则「finished 带部分数据」就是在断言空气。
- fixture 每次深拷贝，因为 `clean_comments` 会就地填默认值。

## 非空验证

每一轮改动都做了反向验证——先破坏契约确认变红，再还原确认转绿：

| 注入的破坏 | 被哪条抓住 |
|---|---|
| 分析进度重标到 70–95 | `Lists differ: [82] != [50]` |
| 空结果改成抛错 | `True is not false` |
| `analysis.latest` 返回原始 result | 键集断言，暴露 `_asset_context` / `_asset_dir` 泄漏 |
| 多发一个 `log` 帧 | **4 条**序列断言同时变红 |
| `DataProcessor` 少一个 `avg_likes` 字段 | 成功路径与停止路径的 stats 断言 |
| 吞掉爬虫的停止日志 | 停止路径的序列断言 |

## 测试

| | |
|---|---|
| Python（venv，含 MCP） | 111 通过 |
| Python（全局，无 mcp） | 96 通过，1 跳过 |
| 桌面 TS | 9 通过 |
| `backend/` 与 `src/` | 零改动 |

## 下一步

第 2 步（分离调用方策略与单次请求参数）单独开 PR，不叠在这个上面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
