### PR TITLE
fix: preserve empty outcome on pre-worker cancellation

### DIFF
--- a/src/service/agent_service.py
+++ b/src/service/agent_service.py
@@ -548,9 +548,11 @@ class AgentService:
         max_pages = int(params["max_pages"])
 
         # A cancel that arrived before the crawl started must not fire off
-        # requests anyway.
+        # requests anyway. Desktop callers still need the same explicit empty
+        # outcome they receive when cancellation lands after crawler creation.
         if task.cancel_event.is_set():
-            self._settle(task, "评论爬取完成")
+            changes = self._crawl_results(task, []) if self._policy.empty_crawl_is_success else {}
+            self._settle(task, "评论爬取完成", **changes)
             return
 
         def progress(message: str) -> None:

--- a/tests/test_sidecar_characterization.py
+++ b/tests/test_sidecar_characterization.py
@@ -416,6 +416,47 @@ class CommentCrawlBaseline(unittest.TestCase):
 
 
 class CommentStopBaseline(unittest.TestCase):
+    def test_stop_before_the_worker_builds_a_crawler_finishes_empty(self) -> None:
+        run_root = tempfile.TemporaryDirectory()
+        self.addCleanup(run_root.cleanup)
+        env_patch = patch.dict(os.environ, {"BILIBILI_AGENT_RUNS_DIR": run_root.name})
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
+        worker_started = threading.Event()
+        release_worker = threading.Event()
+        sidecar, _ = make(comments=[COMMENT_A])
+        self.addCleanup(drain, sidecar)
+        self.addCleanup(release_worker.set)
+        original_persist = sidecar._agent_service._persist
+        first_persist = True
+
+        def blocking_first_persist(task):
+            nonlocal first_persist
+            if first_persist:
+                first_persist = False
+                worker_started.set()
+                if not release_worker.wait(timeout=5):
+                    raise TimeoutError("comment worker was never released")
+            return original_persist(task)
+
+        sidecar._agent_service._persist = blocking_first_persist
+        sidecar.handle({"id": "req-1", "method": "comments.start",
+                        "params": {"input": "BV1xx411c7mD", "max_pages": 5}})
+        self.assertTrue(worker_started.wait(timeout=5))
+
+        deadline = time.monotonic() + 5
+        while not sidecar._active_agent_task_id and time.monotonic() < deadline:
+            threading.Event().wait(0.01)
+        self.assertTrue(sidecar._active_agent_task_id)
+
+        sidecar.handle({"id": "req-2", "method": "task.stop", "params": {}})
+        release_worker.set()
+        drain(sidecar)
+
+        self.assertFalse(sidecar.has("error", "comments"))
+        self.assertEqual(sidecar.event("finished", "comments")["count"], 0)
+        self.assertEqual(sidecar.event("stats", "comments")["stats"], EMPTY_STATS)
+
     def test_stop_before_the_sidecar_receives_the_task_id_is_forwarded(self) -> None:
         crawl_gate = threading.Event()
         return_gate = threading.Event()


### PR DESCRIPTION
## Summary
- preserve the desktop empty-result outcome when cancellation lands before crawler construction
- add a deterministic characterization test for the pre-worker cancellation window
- keep legacy empty-crawl policy behavior unchanged

## Verification
- RED before fix and after temporary reverse verification
- python -m unittest discover -s tests -q: 167 tests, 1 skipped
- same suite with mcp==2.1.0: 182 tests
- desktop Node tests: 9/9
- py_compile: passed