### PR TITLE
Fix the cargo check ordering in the v3.4.0 checklist

### DIFF
--- a/docs/RELEASE_3.4.0.md
+++ b/docs/RELEASE_3.4.0.md
@@ -43,7 +43,12 @@
   与 `corepack pnpm@10.28.0 run typecheck`。
 - [ ] 前端构建：在 `desktop/` 运行 `corepack pnpm@10.28.0 run build`。
 - [ ] 依赖审计：在 `desktop/` 运行 `corepack pnpm@10.28.0 audit`。
-- [ ] Rust 检查：`cargo check --locked --manifest-path desktop/src-tauri/Cargo.toml`。
+- [ ] Rust 检查：**必须在 sidecar 构建完成之后**运行。先
+  `powershell -ExecutionPolicy Bypass -File scripts/build_backend.ps1 -Python $ReleasePython`
+  生成 `desktop/src-tauri/resources/backend`，再运行
+  `cargo check --locked --manifest-path desktop/src-tauri/Cargo.toml`。干净 checkout 里该目录不存在，
+  `tauri.conf.json` 又把它声明为打包资源，先跑 cargo check 会直接以
+  `resource path resources\backend doesn't exist` 失败。
 - [ ] 基础卫生：合并后设置 `$CandidateSha = git rev-parse HEAD`，运行
   `git diff --check "$CandidateSha^1" $CandidateSha`。
 - [ ] GitHub Actions `Python package gate` 在候选提交对应的 `main` push 上为绿：一次构建产物、
@@ -128,7 +133,11 @@
 - [ ] 更新本地 `main` 到 `origin/main`，确认工作区干净且没有未合并发布提交；设置
   `$CandidateSha = git rev-parse HEAD`。
 - [ ] 从 `$CandidateSha` 创建全新干净 worktree，断言其中 `git rev-parse HEAD` 等于 `$CandidateSha`
-  且 `git status --porcelain` 为空；在该 worktree 中重新运行第 2 节全部本机门禁。
+  且 `git status --porcelain` 为空；在该 worktree 中重新运行第 2 节全部本机门禁。门禁内部有顺序依赖：
+  Rust 检查排在 `build_backend.ps1` 之后，其余各项可先行。`build_installer.ps1` 会再次调用
+  `build_backend.ps1`，重复构建 sidecar 是预期行为。
+- [ ] worktree 放在短路径下（例如与仓库同级的 `BilibiliCommentsCrawler-worktrees\`）。`node_modules`
+  与 Rust target 会叠加很深的相对路径，深目录下的创建或删除会遇到 Windows `Filename too long`。
 - [ ] 在该 worktree 中使用全新 CPython 3.13.15 x64 构建环境重新运行 `scripts/build_installer.ps1`；
   只有这次构建生成的安装包才是最终 Release 资产。
 - [ ] 设置 `$Installer = Resolve-Path 'desktop/src-tauri/target/release/bundle/nsis/BilibiliCrawler-Setup-3.4.0-x64.exe'`，


### PR DESCRIPTION
## Why

Running the v3.4.0 gates on candidate `303b81b` failed at the Rust step:

```
resource path `resources\backend` doesn't exist
cargo_check_exit=101
```

`desktop/src-tauri/tauri.conf.json` declares `"resources": ["resources/backend"]`, and that directory is produced by `scripts/build_backend.ps1` via PyInstaller. A clean worktree does not have it.

Section 2 of the checklist listed `cargo check --locked` as a standalone gate, dropping the "after the sidecar build" qualifier that `RELEASE_3.3.0.md` carried. Section 6 then asks for all section 2 gates to be re-run in a clean worktree, so the checklist as written could not pass in the environment it mandates.

## What changes

- Section 2: state that the Rust check runs only after `scripts/build_backend.ps1`, name the resource it produces, and record the exact failure that occurs otherwise.
- Section 6: note the intra-gate ordering dependency, and that `build_installer.ps1` re-runs `build_backend.ps1` so the repeated sidecar build is expected.
- Section 6: add the worktree path-length constraint. A deep scratch path made both `node_modules` creation and deletion fail with Windows `Filename too long`, so the release worktree belongs next to the repository, which is where the v3.3.0 build ran.

## Validation

- Documentation only. No code, workflow, dependency, or version change.
- `git diff --check` passed.
- The other gates already passed on `303b81b` and are unaffected: Python 299 (3 expected skips) and 330/330, desktop audit clean, typecheck, build, and 13/13 unit tests.

## Boundaries

- No tag, Release, installer build, or package upload is performed here.
- This resets the v3.4.0 candidate commit again: the installer must be built from the merge commit of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
