### PR TITLE
Close out the v3.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ manifest 中的 artifacts 路径相对于 run 目录存储（拷贝到其他机�
 - JSON：完整分析结构，包含可视化图表数据层和元信息（含 `schema_version` 与 `elapsed_seconds` 耗时）。
 - Markdown 图表资源会写入报告同级的 assets 目录；词云图直接复用 sidecar 生成的 PNG 文件。
 
+## 项目规划
+
+当前候选验收、兼容性修复、发布任务和后续工程工作见
+[BilibiliCrawler 前瞻计划](docs/FORWARD_PLAN.md)。历史版本计划仅保留对应阶段记录，不再追加新任务。
+
 ## 源码开发
 
 ### 环境要求
@@ -350,7 +355,7 @@ BilibiliCrawler/
 
 ## 更新日志
 
-### v3.4.0（待发布）
+### v3.4.0 (2026.09.02)
 - 新增可安装的 `bilibili-crawler` Python 包与 `bilibili-crawler`、`bilibili-crawler-mcp` 稳定命令，支持 Python 3.10–3.13；旧源码入口保留为薄兼容层。
 - 桌面端、CLI 与 MCP 统一按同一个 profile 解析 provider、model 与 API Key，避免把凭据发往错误端点。
 - 新增只读 `doctor` 诊断，展示配置来源、有效 provider/model、运行目录与 MCP 状态；只有显式要求联网检查时才访问 provider。
@@ -360,7 +365,8 @@ BilibiliCrawler/
 - 补齐真实 MCP stdio 子进程验收，覆盖中文内容、Windows 编码、进程重启复用 run 与可选 live smoke。
 - Windows 上目录发布遇到短暂共享锁（WinError 5/32）时按有限退避重试；持续锁与目标冲突仍 fail-closed。
 - 新增 Python 包 CI 门禁与手工发布链路：产物哈希锁定、源码逐字节绑定，GitHub Release → TestPyPI → PyPI 顺序发布并使用 OIDC Trusted Publishing。
-- 发布前仍须完成 `docs/RELEASE_3.4.0.md` 中的 Tauri 真机验收与包发布门禁；完成后再填写发布日期并创建标签。
+- 已按 `docs/RELEASE_3.4.0.md` 完成真机验收与发布门禁。标签 `v3.4.0` 指向 `dc71f58`；Windows x64 安装包随
+  GitHub Release 发布，`bilibili-crawler` 3.4.0 已上架 PyPI，两处与 Release 资产的 SHA-256 一致。
 
 ### v3.3.0 (2026.08.30)
 - 桌面评论爬取与 `source == "comments"` 的分析已迁入共享 `AgentService`，同时保留既有 RPC、事件、取消、空结果和 source 回退契约。

--- a/docs/FORWARD_PLAN.md
+++ b/docs/FORWARD_PLAN.md
@@ -1,0 +1,111 @@
+# BilibiliCrawler 前瞻计划
+
+> 状态：执行中
+>
+> 建立日期：2026-09-02
+>
+> 适用范围：v3.4.0 候选验收、发布收尾及后续兼容性工作
+>
+> 本文档是当前前瞻任务的权威入口；历史阶段记录继续保留在对应版本文档中，不再向
+> `POST_3.3.0_PLAN.md` 追加新任务。
+
+## 任务总览
+
+| 优先级 | 任务 | 状态 | 完成标准 |
+|---|---|---|---|
+| P0 | 完成 v3.4.0 桌面真机验收 | 已完成 | 完成爬取、取消、重试、分析、导出、凭据脱敏、升级与卸载数据保留检查，并记录证据 |
+| P1 | 修复 CLIProxyAPI Antigravity HTTP 400 参数兼容问题 | 规划中 | 精确识别被拒参数，安全兼容重试通过，普通 400 不被误重试，安装版 live smoke 通过 |
+| P1 | 完成 Python 包远端发布配置 | 已完成 | TestPyPI 与 PyPI Trusted Publisher 配置完成，GitHub environments 规则复核通过 |
+| P1 | 完成 v3.4.0 正式发布 | 已完成 | 从干净 worktree 构建正式资产，标签、GitHub Release、TestPyPI、PyPI 依次验证通过 |
+| P2 | 复盘安装器跨构建覆盖残留 | 待评估 | 明确旧 sidecar 文件残留的影响，决定由安装器清理、版本化目录或文档约束处理 |
+
+详细发布步骤与不可逆边界继续以 [v3.4.0 发布准备与验收清单](RELEASE_3.4.0.md) 为准。
+
+## P0：v3.4.0 桌面真机验收
+
+已完成。2026-09-02 在候选 `526e8cc` 的预检安装包上按下列顺序逐项执行，全部通过、未发现问题；
+产物与门禁证据见 [v3.4.0 清单](RELEASE_3.4.0.md) 的验收记录。
+
+原检查顺序：
+
+1. 检查当前 Windows 缩放下的任务栏图标、桌面与开始菜单快捷方式。
+2. 完成普通评论爬取，核对进度、评论数量、CSV 与 run 目录。
+3. 在爬取过程中取消并立即重试，确认部分结果、单一终态和重试能力。
+4. 完成评论分析，核对结构化结果、词云、`analysis.json` 与 Markdown 报告。
+5. 在分析过程中取消并立即重试，确认不会出现迟到的成功终态。
+6. 验证错误 provider/model 的分类提示，以及修正配置后复用原 run 的恢复能力。
+7. 用 canary Key 分析后扫描完整 run，确认持久化文件零命中。
+8. 完成 v3.3.0 → v3.4.0 覆盖升级和默认卸载的数据保留验证。
+
+任何失败均记录为独立任务，不用自动化测试替代真实窗口观察。
+
+## P1：CLIProxyAPI Antigravity HTTP 400 参数兼容
+
+### 已确认事实
+
+- 复现环境为 CLIProxyAPI `7.2.145`、commit `d9cea890`，监听 `127.0.0.1:8317`。
+- BilibiliCrawler Base URL 应为 `http://127.0.0.1:8317/v1`；客户端会追加 `/chat/completions`。
+- 模型 `gemini-3.7-flash-high` 出现在已认证模型列表中，`owned_by` 为 `antigravity`。
+- 正确的 `POST /v1/chat/completions` 多次在约 0.3–1.8 秒内返回 HTTP 400，不是连接或读取超时。
+- `/chat/completions` 与 `/v1/chat/completions/chat/completions` 的 404 来自错误 Base URL，不是产品故障。
+- 诊断产生的 `/v1/models` 401→200 和 Management API 404 不计入产品故障。
+- 先前显示第 3/4 批的进度使用的是 DeepSeek API，不能作为 CLIProxyAPI 已成功完成前两批的证据。
+- 失败只影响新的 analysis attempt；原 run、评论和上一份有效报告仍然保留。
+
+### 当前假设与边界
+
+BilibiliCrawler 的批次请求固定发送 `temperature: 0.2`，总结合并请求发送 `temperature: 0.18`，
+两者均发送 `response_format: {"type":"json_object"}`。Antigravity 上游存在拒绝采样字段并返回 400
+的同类记录，因此 `temperature` 是首要嫌疑，`response_format` 是次要嫌疑。
+
+当前安全错误表面不会展示远端响应正文，CLIProxyAPI 请求错误日志也未提供本次具体字段，因此上述判断仍是
+待验证假设。不得把任意 HTTP 400 直接认定为同一种兼容问题。
+
+### 实施步骤
+
+1. 扩展 provider 错误解析，只提取并传递脱敏后的 HTTP status、error code 与 param。
+2. 保持远端正文、API Key、prompt、评论内容不进入日志、快照、manifest、分析 JSON 或报告。
+3. 仅当结构化错误明确指出 `temperature` 不受支持时，移除该字段并占用共享重试预算重新请求。
+4. 保留现有的 `response_format` 精确降级、最多三次请求、取消和退避语义。
+5. 任意 400、模糊错误或其他参数错误继续 fail closed，不自动删字段或重放请求。
+6. 修复完成后重建 sidecar 与安装包，以相同 CLIProxyAPI/Antigravity 配置执行 live smoke。
+
+### 验收标准
+
+- 显式 `temperature` unsupported 错误先由回归夹具复现，修复后只重试一次且第二次请求不含该字段。
+- `response_format` 的既有兼容降级继续通过。
+- 无关参数错误、空错误体和普通 HTTP 400 均不重试。
+- 重试预算、取消、超时与旧报告保留语义不变。
+- 合成凭据与远端正文 canary 在 stdout、stderr、日志、快照和完整 run 目录中零命中。
+- 普通 Python、MCP、桌面单元与真实 SidecarClient 门禁全部通过。
+- 安装版使用 `gemini-3.7-flash-high` 完成至少一次最小分析；若上游仍拒绝，记录脱敏 code/param 并维持未完成状态。
+
+## P1：远端配置与 v3.4.0 发布
+
+已完成。v3.4.0 于 2026-09-02 公开发布，标签指向 `dc71f58`：GitHub Release 带 Windows x64 安装包
+与四个 Python 资产，`bilibili-crawler` 3.4.0 已上架 PyPI，三处产物 SHA-256 一致。逐项证据见
+[v3.4.0 清单](RELEASE_3.4.0.md)。
+
+原执行步骤：
+
+1. 在 TestPyPI 与 PyPI 配置 `bilibili-crawler` 的 pending Trusted Publisher。
+2. 复核 GitHub `testpypi`、`pypi` environments 仅允许 `main`，且 `pypi` 保留人工 reviewer。
+3. 真机验收和所有阻断修复完成后，从干净 worktree 重新构建正式安装包及 Python 资产。
+4. 创建 annotated `v3.4.0` 标签与 Draft Release，验证所有资产和校验文件。
+5. 依次执行 GitHub Release、TestPyPI、PyPI 发布与公共下载验证，不跳步或复用失败资产。
+
+## P2：安装器覆盖残留评估
+
+同版本候选覆盖安装时发现，当前 NSIS 卸载清单不会删除旧安装器遗留但新安装器不再包含的
+sidecar `_internal` 文件。人工验收前已通过备份、默认卸载、移动旧 sidecar 目录和重装获得干净环境，
+用户数据未受影响。
+
+后续需评估正式方案：安装前精确清理程序资源目录、使用版本化资源目录，或在版本升级策略中显式约束。
+任何方案都必须严格排除 `user-data`、`analysis-runs`、`analysis-assets` 等用户数据目录，并补充升级回归。
+
+## 状态维护规则
+
+- 只有实现、测试和对应验收证据全部完成后，任务才能标记为完成。
+- 外部服务偶发成功不能替代可复现证据，历史 provider 的成功也不能证明新 provider 兼容。
+- 新发现写入本文档对应任务；版本发布细节写入版本清单，历史版本计划不再追加新工作。
+- 对涉及 Key、Cookie、OAuth 或远端错误正文的证据只记录脱敏后的结构化信息。

--- a/docs/RELEASE_3.4.0.md
+++ b/docs/RELEASE_3.4.0.md
@@ -1,7 +1,8 @@
 # v3.4.0 发布准备与验收清单
 
-> 状态：Release Candidate 准备中。清单未逐项勾选前不得创建标签、上传 Release 资产或向
-> TestPyPI / PyPI 发布。批次进度见 [v3.3.0 后续实施计划](POST_3.3.0_PLAN.md)，包发布治理见
+> 状态：**v3.4.0 已于 2026-09-02 公开发布**，标签指向 `dc71f58`。下文保留原始发布准备清单与
+> 验收记录；未勾选项是执行时按顺序完成的模板项，不代表当前发布状态。后续版本另建清单，本文不再
+> 追加新任务。批次进度见 [v3.3.0 后续实施计划](POST_3.3.0_PLAN.md)，包发布治理见
 > [Python 包发布治理](PYTHON_PACKAGE_RELEASE.md)，面向用户的说明见
 > [v3.4.0 发布说明](RELEASE_NOTES_3.4.0.md)。
 
@@ -223,3 +224,19 @@
 - 过程中修正的两处清单缺陷：`cargo check` 缺少「sidecar 构建之后」的顺序前提（`5bd7440`），
   以及 worktree 干净判据应为无内容变更而非 `git status` 为空（本次）。
   另有一处依赖告警在候选中修复：`browserslist` 经 pnpm overrides 锁到 4.28.8（`cfd9601`）。
+- 第 6 节在最终候选 `dc71f58` 上完成，门禁全部重跑通过（无 MCP 299/3 跳过、MCP 330/330、
+  desktop 五项、`build_backend.ps1` 后 `cargo check --locked`）。正式产物：
+  `BilibiliCrawler-Setup-3.4.0-x64.exe`，53,480,344 字节，
+  SHA-256 `60202e26bc29799104f3eb610fa1e196219f469f05467bd2215046277978d715`，
+  构建完成 2026-09-02T14:50:38+08:00。`.sha256` 校验文件已反向解析核对。
+- 标签 `v3.4.0` 为 annotated，远端 peeled SHA 等于 `dc71f58`。
+- Python 产物：wheel 110,270 字节 `1d6e514e…50cc90`；sdist 108,792 字节 `8a9aedf4…4ce8b0`；
+  `python-package-manifest.json` 的 `source_commit` 等于标签指向的提交。
+  GitHub Release、TestPyPI 与 PyPI 三处哈希一致，全程复用同一份不可变产物。
+- 发布顺序按第 6 节执行：Draft（安装包 + 校验文件）→ 工作流 `github-release` 附加四个 Python 资产 →
+  下载全部资产反向核验 → 公开 Release → `testpypi` → `pypi`（经 `pypi` environment 人工审批）。
+  每个阶段的工作流均为 success，含六分片干净安装与索引下载安装 smoke。
+- 发布后本机独立验证：CPython 3.13.15 新建 venv 从 PyPI 安装
+  `bilibili-crawler[mcp]==3.4.0`，`pip check` 无破损；`--help` 与只读 `doctor` 正常且无凭据泄露；
+  `bilibili-crawler-mcp` stdio 握手成功，协议 `2025-11-25`，发现 7 个工具。
+- Release 说明已补充构建提交、三个产物的大小与 SHA-256，以及未代码签名的 SmartScreen 提示。


### PR DESCRIPTION
## Why

v3.4.0 is published, but the documentation still described it as unreleased. Tag `v3.4.0` points at `dc71f58`, the GitHub Release carries the Windows x64 installer plus four Python assets, and `bilibili-crawler` 3.4.0 is on PyPI with SHA-256 matching the Release assets and TestPyPI.

## What changes

- **README**: date the v3.4.0 changelog entry (2026.09.02) and replace the "acceptance still pending" line with the tag, installer and PyPI facts. Also track the previously uncommitted 项目规划 section, so its link to the forward plan resolves on `main`.
- **RELEASE_3.4.0.md**: mark the checklist as released, and record the section 6 evidence — final installer size and SHA-256, annotated tag verification, wheel/sdist hashes, the ordered publication stages, and the post-release clean-environment install check.
- **FORWARD_PLAN.md**: start tracking this file, mark the acceptance, remote publishing configuration and release tasks complete, and leave the Antigravity HTTP 400 compatibility and installer residue tasks open.

## Release facts recorded

| Artifact | Size | SHA-256 |
|---|---|---|
| `BilibiliCrawler-Setup-3.4.0-x64.exe` | 53,480,344 | `60202e26…78d715` |
| `bilibili_crawler-3.4.0-py3-none-any.whl` | 110,270 | `1d6e514e…50cc90` |
| `bilibili_crawler-3.4.0.tar.gz` | 108,792 | `8a9aedf4…4ce8b0` |

Post-release verification on a clean CPython 3.13.15 venv: `pip install "bilibili-crawler[mcp]==3.4.0"` succeeded, `pip check` clean, `--help` and read-only `doctor` behaved, and `bilibili-crawler-mcp` completed a stdio handshake discovering all 7 tools.

## Note on formatting

The forward plan's header used trailing double spaces as Markdown hard breaks. `git diff --check` rejects trailing whitespace, so the same layout is now expressed with blockquote paragraphs. No wording changed.

## Boundaries

- Documentation only. No code, workflow, dependency, or version change.
- Nothing is published by this PR; v3.4.0 is already released and this only records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
