### PR TITLE
fix: drop temperature when the provider names it as the rejected field

### DIFF
--- a/bilibili_crawler/processor/analysis_processor.py
+++ b/bilibili_crawler/processor/analysis_processor.py
@@ -432,6 +432,10 @@ class LLMAnalysisProcessor:
                         updates.put(f"格式兼容降级 · 即将请求 {attempt + 2}/3（重试 {attempt + 1}）")
                         request_payload.pop("response_format")
                         continue
+                    if attempt < 2 and failure.drop_temperature and "temperature" in request_payload:
+                        updates.put(f"采样参数兼容降级 · 即将请求 {attempt + 2}/3（重试 {attempt + 1}）")
+                        request_payload.pop("temperature")
+                        continue
                     delay = failure.retry_after if failure.retry_after is not None else float(attempt + 1)
                     if not failure.retryable or attempt == 2 or delay > 10:
                         raise AnalysisError(f"{request_error}: {failure}", code=failure.code) from None

--- a/bilibili_crawler/processor/provider_errors.py
+++ b/bilibili_crawler/processor/provider_errors.py
@@ -24,11 +24,13 @@ class AnalysisCancelled(AnalysisError):
 
 class ProviderError(AnalysisError):
     def __init__(self, code: str, message: str, *, retryable: bool = False,
-                 retry_after: float | None = None, drop_response_format: bool = False):
+                 retry_after: float | None = None, drop_response_format: bool = False,
+                 drop_temperature: bool = False):
         super().__init__(message, code=code)
         self.retryable = retryable
         self.retry_after = retry_after
         self.drop_response_format = drop_response_format
+        self.drop_temperature = drop_temperature
 
 
 def retry_after_seconds(value: str | None) -> float | None:
@@ -114,9 +116,21 @@ def classify_http_error(response: requests.Response) -> ProviderError:
                 message,
             ))
         )
+        # `param` is the provider naming the field it refused, and that is the
+        # whole signal: the accompanying code varies by model family and says
+        # nothing extra about which field failed. OpenAI's reasoning models
+        # answer with `param: "temperature"` under both `code: null` /
+        # `type: invalid_request_error` and `code: "unsupported_value"`, so
+        # requiring an unsupported-class code would miss the commoner shape.
+        # Either reading -- the field is unsupported, or the value is out of
+        # range -- is repaired by dropping it and letting the default stand.
+        # Free text alone still proves nothing, and an absent `param` leaves
+        # the culprit unknown: both fail closed.
+        temperature_rejected = param == "temperature"
         return ProviderError(ErrorCode.LLM_REQUEST_INVALID,
                              f"LLM 请求配置不被接受（HTTP {status}），请核对服务支持的参数。{_error_detail(error)}",
-                             drop_response_format=format_rejected)
+                             drop_response_format=format_rejected,
+                             drop_temperature=temperature_rejected)
     if status in {404, 405} or 300 <= status < 400:
         return ProviderError(ErrorCode.LLM_ENDPOINT, f"LLM 端点或路由不可用（HTTP {status}），请核对 base_url 与模型配置。")
     if status in {500, 502, 503, 504}:

--- a/docs/PROVIDER_RECOVERY.md
+++ b/docs/PROVIDER_RECOVERY.md
@@ -5,7 +5,11 @@ C 批，基线 `326bf58`。不更改 MCP/RPC 字段、超时配置或 UI，不�
 - 分析错误使用稳定 error_code：`LLM_AUTH`、`LLM_MODEL`、`LLM_ENDPOINT`、`LLM_NETWORK`、`LLM_TLS`、`LLM_TIMEOUT`、`LLM_RATE_LIMIT`、`LLM_UNAVAILABLE`、`LLM_RESPONSE_INVALID`、`LLM_REQUEST_INVALID`；非 provider 分析错误保留 `ANALYSIS_FAILED`。
 - 401/403 优先归为鉴权；仅结构化 error.code/type 或 param 明确指向模型时归为模型配置。普通 404 属于端点/路由待核对，不断言模型不存在。其余 400/422 是请求配置错误。
 - 仅 400/422 且明确拒绝 response_format 时移除该字段重发一次；不得对所有 400/404/422 盲目重发。
-- 每个聊天请求最多发送三次（包括格式降级）。429（非额度耗尽）、500/502/503/504、ConnectTimeout 可重试；默认退避 1、2 秒。有效 Retry-After（秒数或 HTTP 日期）优先；超过 10 秒时交由用户稍后重试，不提前发送。
+- 仅 400/422 且 `error.param` 精确等于 `temperature` 时移除该字段重发一次。判据只看 `param`：它就是
+  provider 自己指认的被拒字段，同行的 `code`/`type` 随模型系列变化，对"哪个字段出错"不再增加信息。
+  自由文本、缺少 `param`、`param` 指向其他字段一律 fail closed，不删字段、不重发。两种降级各自
+  只发生一次（字段移除后条件自然不再成立），共用同一个三次请求预算。
+- 每个聊天请求最多发送三次（包括格式与采样参数降级）。429（非额度耗尽）、500/502/503/504、ConnectTimeout 可重试；默认退避 1、2 秒。有效 Retry-After（秒数或 HTTP 日期）优先；超过 10 秒时交由用户稍后重试，不提前发送。
 - 鉴权、模型、端点、TLS、无效配置、解析失败、额度耗尽不自动重试。读取超时/普通连接中断可能已经消费额度，不自动重放；提供人工重试指引。请求取消时等待立即结束，迟到响应不得发起下一次请求。
 - 不跟随 provider 重定向。错误只输出固定安全说明与状态码，不透传原响应正文、异常文本、JSON 预览、URL 或凭据；成功结果仍走已有脱敏边界。
 - 400/422 的安全说明可附带 provider 自报的 `code`/`type`、`param` 与 `status`，用于指出被拒的是什么，
@@ -16,11 +20,26 @@ C 批，基线 `326bf58`。不更改 MCP/RPC 字段、超时配置或 UI，不�
 ## 已观察到的上游错误形状
 
 - OpenAI 兼容服务用 `code`/`type` 加 `param` 指明被拒字段，`response_format` 的精确降级依赖它。
+- OpenAI 推理模型（o1/o3/gpt-5 系列）拒绝采样参数时有两种正文，只在 `param` 上一致：
+
+  ```json
+  {"error":{"message":"Unsupported parameter: 'temperature' is not supported with this model.",
+            "type":"invalid_request_error","param":"temperature","code":null}}
+  {"error":{"message":"Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported.",
+            "type":"invalid_request_error","param":"temperature","code":"unsupported_value"}}
+  ```
+
+  第一种更常见，`code` 为 `null`、`type` 是通用的 `invalid_request_error`。若要求 code 属
+  unsupported 类才降级，就会漏掉它——所以判据只看 `param`。本仓库固定发送 `temperature`
+  0.2 / 0.18，指向这类模型时若不降级就是硬失败。
 - Google 系（经 CLIProxyAPI 的 Antigravity 通道，上游 `daily-cloudcode-pa.googleapis.com`）把 HTTP
   状态码放进 `error.code`，真正可操作的信息在 `error.status` 枚举里，`message` 是自由文本。
   2026-09-02 观察到的 10 次分析失败全部是 `status: FAILED_PRECONDITION`，属于上游对调用方所在区域的
   限制，与请求参数无关：`temperature` 与 `response_format` 原样送达且从未被评估。
   这类失败不能靠删字段重发绕过，本仓库也无法修复；分类保持 fail closed，只把 `status` 透出来供排查。
+  **`temperature` 降级不针对也不解决这个问题**：该正文没有 `param`，`code` 是数值 400，触发条件
+  不成立；即使成立，请求在参数被读取之前就已经被拒。上游侧的处理是让 CLIProxyAPI 通过受支持区域的
+  出口访问（按认证配置 proxy-url），与本仓库无关。不要因为再次看到 Antigravity 400 就放宽降级条件。
 - 批次与总结请求共用分类。保留既有“总结整合失败时使用已完成批次总结”的降级行为，并在结果/任务 warnings 记录安全错误码和提示，不丢弃已付费批次。
 - 爬取已完成而分析失败：保留评论文件与 run_id；CLI/MCP 提示按错误修正配置或等待，再调用 analyze-run/analyze_run 复用原 run，不默认重新爬取。已有有效报告时遵循 B 的尝试与有效 run 分离语义。
 - 测试使用本地 HTTP provider、传输异常及取消夹具；检查真实调用次数、原 run 评论哈希、错误码在 manifest/CLI/MCP 的一致性，以及错误回显/成功产物的 canary 零泄露。外部付费调用和完整 MCP stdio 验收不属于本批。

--- a/tests/test_provider_recovery.py
+++ b/tests/test_provider_recovery.py
@@ -93,7 +93,7 @@ class ProviderTests(unittest.TestCase):
             self.assertNotIn("response_format", calls[1])
 
     def test_other_parameter_error_does_not_trigger_format_fallback(self):
-        for param in ("temperature", None):
+        for param in ("top_p", None):
             body = {"error": {"param": param, "code": "unsupported_parameter",
                               "message": "temperature is not supported; response_format is supported"}}
             with self.subTest(param=param), provider([(400, body, {})]) as (url, calls):
@@ -105,6 +105,91 @@ class ProviderTests(unittest.TestCase):
                        (200, SUCCESS, {})]) as (url, calls):
             self.assertEqual(self.call(url)["summary"], "recovered")
             self.assertEqual(len(calls), 2)
+
+    def test_both_observed_temperature_rejections_drop_only_that_field(self):
+        # Verbatim shapes returned by OpenAI's reasoning models. They differ in
+        # `code`/`type` and agree only on `param`, which is why the trigger
+        # reads `param` alone.
+        shapes = [
+            {"error": {"message": "Unsupported parameter: 'temperature' is not supported with this model.",
+                       "type": "invalid_request_error", "param": "temperature", "code": None}},
+            {"error": {"message": "Unsupported value: 'temperature' does not support 0.2 with this model."
+                                  " Only the default (1) value is supported.",
+                       "type": "invalid_request_error", "param": "temperature", "code": "unsupported_value"}},
+            # Some proxies forward `param` and drop the rest entirely.
+            {"error": {"message": f"{KEY} {BODY_MARKER}", "param": "temperature"}},
+        ]
+        for body in shapes:
+            with self.subTest(code=body["error"].get("code")), \
+                    provider([(400, body, {}), (200, SUCCESS, {})]) as (url, calls):
+                self.assertEqual(self.call(url)["summary"], "recovered")
+                self.assertEqual(len(calls), 2)
+                self.assertIn("temperature", calls[0])
+                self.assertNotIn("temperature", calls[1])
+                # Only the named field goes; the rest of the payload stands.
+                self.assertIn("response_format", calls[1])
+                self.assertEqual({k: v for k, v in calls[0].items() if k != "temperature"}, calls[1])
+
+    def test_temperature_is_kept_unless_the_provider_names_it(self):
+        bodies = [
+            # Free text alone never establishes which field was refused.
+            {"error": {"message": "Unsupported parameter: 'temperature' is not supported with this model."}},
+            {"error": {"code": "unsupported_parameter",
+                       "message": "temperature is not supported with this model"}},
+            # A structured rejection naming another field must not drop it.
+            {"error": {"code": "unsupported_value", "param": "top_p", "message": f"{KEY} {BODY_MARKER}"}},
+            {"error": {}},
+        ]
+        for body in bodies:
+            with self.subTest(body=json.dumps(body)), provider([(400, body, {})]) as (url, calls):
+                with self.assertRaises(AnalysisError) as raised:
+                    self.call(url)
+                self.assertEqual(raised.exception.code, "LLM_REQUEST_INVALID")
+                self.assertEqual(len(calls), 1)
+                self.assertNotIn(KEY, str(raised.exception))
+                self.assertNotIn(BODY_MARKER, str(raised.exception))
+
+    def test_google_style_precondition_failure_is_never_treated_as_a_parameter_problem(self):
+        # The shape CLIProxyAPI/Antigravity actually returns: an egress-region
+        # restriction, evaluated before any parameter is read. Dropping fields
+        # cannot help, so the crawler must not spend the budget trying.
+        body = {"error": {"code": 400, "status": "FAILED_PRECONDITION",
+                          "message": f"User location is not supported for the API use. {BODY_MARKER}"}}
+        with provider([(400, body, {})]) as (url, calls):
+            with self.assertRaises(AnalysisError) as raised:
+                self.call(url)
+            self.assertEqual(raised.exception.code, "LLM_REQUEST_INVALID")
+            self.assertEqual(len(calls), 1)
+            self.assertIn("temperature", calls[0])
+            self.assertIn("status=failed_precondition", str(raised.exception))
+            self.assertNotIn(BODY_MARKER, str(raised.exception))
+
+    def test_repeated_temperature_rejection_is_not_replayed_without_progress(self):
+        # The field is gone after the first drop, so a second identical
+        # rejection must end the attempt instead of looping on an unchanged
+        # payload.
+        with provider([(400, error_body("unsupported_value", "temperature"), {})]) as (url, calls):
+            with self.assertRaises(AnalysisError) as raised:
+                self.call(url)
+            self.assertEqual(len(calls), 2)
+            self.assertEqual(raised.exception.code, "LLM_REQUEST_INVALID")
+            self.assertNotIn("temperature", calls[1])
+
+    def test_both_compatibility_drops_share_the_single_request_budget(self):
+        with provider([(400, error_body("unsupported_parameter", "response_format"), {}),
+                       (400, error_body("unsupported_value", "temperature"), {}),
+                       (200, SUCCESS, {})]) as (url, calls):
+            self.assertEqual(self.call(url)["summary"], "recovered")
+            self.assertEqual(len(calls), 3)
+            self.assertNotIn("response_format", calls[2])
+            self.assertNotIn("temperature", calls[2])
+        with provider([(503, error_body(), {"Retry-After": "0"}),
+                       (400, error_body("unsupported_value", "temperature"), {}),
+                       (503, error_body(), {"Retry-After": "0"})]) as (url, calls):
+            with self.assertRaises(AnalysisError) as raised:
+                self.call(url)
+            self.assertEqual(len(calls), 3)
+            self.assertEqual(raised.exception.code, "LLM_UNAVAILABLE")
 
     def test_request_invalid_surfaces_only_sanitized_identifiers(self):
         with provider([(400, error_body("unsupported_parameter", "top_p"), {})]) as (url, calls):


### PR DESCRIPTION
取代 `codex/provider-temperature-compat`（那个分支基于 `0ed13b3`，与 main 冲突，且自己重实现了一份更旧的 `_error_detail`）。

## 先说 CPA / Antigravity：原假设是错的

`docs/PROVIDER_RECOVERY.md` 里已经记着 2026-09-02 的观察结论——那 10 次 400 全是：

```json
{"error":{"code":400,"status":"FAILED_PRECONDITION","message":"User location is not supported for the API use."}}
```

出口区域限制，请求在参数被读取之前就被拒了。`temperature` 和 `response_format` 原样送达、从未被评估。这个正文**没有 `param`**，`code` 是数值 400，所以旧分支的触发条件根本不成立；就算成立，删字段也不可能有用。上游侧的处理是让 CLIProxyAPI 按认证配置走受支持区域的 proxy-url，与本仓库无关。

本 PR 为此加了一条回归测试钉住这个形状（不重试、不删字段、只透出 `status=failed_precondition`），并在文档里写明「不要因为再看到 Antigravity 400 就放宽降级条件」。

## 但这个机制值得留，为了另一类 provider

OpenAI 推理模型（o1/o3/gpt-5 系列）拒绝采样参数，而本仓库固定发送 `temperature` 0.2 / 0.18——指向这类模型今天就是硬失败。它们的正文有两种，只在 `param` 上一致：

```json
{"message":"Unsupported parameter: 'temperature' is not supported with this model.",
 "type":"invalid_request_error","param":"temperature","code":null}
{"message":"Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported.",
 "type":"invalid_request_error","param":"temperature","code":"unsupported_value"}
```

旧分支要求 `param == "temperature"` **且** code 属 unsupported 类——**漏掉第一种，也就是更常见的那种**。我在本地验证过：把条件换回旧写法，新增测试里的两个 subtest 立刻变红。

所以触发条件只看 `param`：它就是 provider 自己指认的被拒字段；同行的 code 随模型系列变化，对「哪个字段出错」不再增加信息。两种解读（字段不支持 / 取值越界）都由删掉该字段、让默认值生效来修复。

自由文本、缺 `param`、`param` 指向别的字段，仍然 fail closed。降级只发生一次（字段删了条件自然不成立），与 `response_format` 降级共用同一个三次请求预算。

## 验证

Python 363 passed / 214 subtests（排除 live smoke）。新增 5 组测试：两种真实 temperature 正文各自只删该字段、只看 param 的 fail-closed 边界、Antigravity FAILED_PRECONDITION 不被当成参数问题、重复拒绝不空转、两种降级共用预算。

**live smoke 仍未做**，也不再是这个改动的验收条件——原来的 live 目标（CPA/Antigravity）已经确认不是参数问题。要验证这条路径需要一个会拒绝 temperature 的 provider（如 o3-mini）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
