### PR TITLE
fix(desktop): show only update-check failures this app authored

### DIFF
--- a/desktop/src/components/VersionPanel.tsx
+++ b/desktop/src/components/VersionPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { isTauri } from "../lib/tauri";
-import { checkForUpdate, isNewerVersion, type DesktopRelease } from "../lib/updates";
+import { checkFailureMessage, checkForUpdate, isNewerVersion, type DesktopRelease } from "../lib/updates";
 
 export function VersionPanel({ running }: { running: boolean }) {
   const [version, setVersion] = useState<string | null>(() => isTauri() ? null : __APP_VERSION__);
@@ -34,7 +34,7 @@ export function VersionPanel({ running }: { running: boolean }) {
         setMessage(latest.downloadUrl ? `发现新版本 v${latest.version}` : `v${latest.version} 安装包尚未就绪，请稍后重试。`);
       } else setMessage("当前已是最新版本。");
     } catch (error) {
-      setMessage(controller.signal.aborted ? "检查超时或已取消，请重试。" : `无法检查更新：${error instanceof Error ? error.message : String(error)}`);
+      setMessage(checkFailureMessage(error, controller.signal.aborted));
     } finally {
       clearTimeout(timeout);
       pending.current = false;

--- a/desktop/src/lib/updates.ts
+++ b/desktop/src/lib/updates.ts
@@ -1,6 +1,21 @@
 export const RELEASES_URL = "https://github.com/Yi-luo-hua/BilibiliCrawler/releases";
 export const RELEASE_API = "https://api.github.com/repos/Yi-luo-hua/BilibiliCrawler/releases/latest";
 
+/** A failure this module authored, and therefore the only kind safe to show.
+ *
+ * Everything else reaching the caller was written by the network stack or the
+ * JSON parser. A `SyntaxError` from a malformed body can quote the body itself,
+ * so those are reported as a fixed line instead of being printed. */
+export class UpdateCheckError extends Error {}
+
+/** The line to show the user for a failed check. Pure, so it can be tested
+ * without a component: the rule is what matters, not where it is rendered. */
+export function checkFailureMessage(error: unknown, aborted: boolean): string {
+  if (aborted) return "检查超时或已取消，请重试。";
+  if (error instanceof UpdateCheckError) return `无法检查更新：${error.message}`;
+  return "无法检查更新，请检查网络后重试。";
+}
+
 export interface DesktopRelease {
   version: string;
   notes: string;
@@ -10,10 +25,10 @@ export interface DesktopRelease {
 
 function versionParts(version: string): number[] {
   if (!/^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
-    throw new Error("无法识别版本号，请到发布页面检查更新。");
+    throw new UpdateCheckError("无法识别版本号，请到发布页面检查更新。");
   }
   const parts = version.replace(/^v/, "").split(".").map(Number);
-  if (!parts.every(Number.isSafeInteger)) throw new Error("版本号超出有效范围。");
+  if (!parts.every(Number.isSafeInteger)) throw new UpdateCheckError("版本号超出有效范围。");
   return parts;
 }
 
@@ -27,10 +42,10 @@ export function isNewerVersion(latest: string, current: string): boolean {
 }
 
 export function parseRelease(value: unknown): DesktopRelease {
-  if (!value || typeof value !== "object") throw new Error("发布信息格式无效。");
+  if (!value || typeof value !== "object") throw new UpdateCheckError("发布信息格式无效。");
   const release = value as Record<string, unknown>;
   if (release.draft !== false || release.prerelease !== false || typeof release.tag_name !== "string") {
-    throw new Error("未找到可用的正式版本。");
+    throw new UpdateCheckError("未找到可用的正式版本。");
   }
   versionParts(release.tag_name);
   const version = release.tag_name.replace(/^v/, "");
@@ -51,9 +66,16 @@ export async function checkForUpdate(signal?: AbortSignal): Promise<DesktopRelea
     cache: "no-store",
   });
   if (!response.ok) {
-    if (response.status === 403 || response.status === 429) throw new Error("检查过于频繁或访问受限，请稍后重试。");
-    if (response.status === 404) throw new Error("尚无公开的正式版本。");
-    throw new Error(`检查更新失败（HTTP ${response.status}）。`);
+    if (response.status === 403 || response.status === 429) throw new UpdateCheckError("检查过于频繁或访问受限，请稍后重试。");
+    if (response.status === 404) throw new UpdateCheckError("尚无公开的正式版本。");
+    throw new UpdateCheckError(`检查更新失败（HTTP ${response.status}）。`);
   }
-  return parseRelease(await response.json());
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    // Not re-thrown: the parser's message can carry a slice of the body.
+    throw new UpdateCheckError("发布信息无法解析，请到发布页面检查更新。");
+  }
+  return parseRelease(payload);
 }

--- a/desktop/tests/updates.test.ts
+++ b/desktop/tests/updates.test.ts
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { isNewerVersion, parseRelease, checkForUpdate, RELEASES_URL } from "../src/lib/updates.ts";
+import {
+  UpdateCheckError, checkFailureMessage, checkForUpdate, isNewerVersion, parseRelease, RELEASES_URL,
+} from "../src/lib/updates.ts";
 
 const release = () => ({ tag_name: "v3.10.0", draft: false, prerelease: false, body: "Changes", assets: [{
   name: "BilibiliCrawler-Setup-3.10.0-x64.exe", size: 100, state: "uploaded",
@@ -41,6 +43,41 @@ test("handles successful checks, rate limits and missing releases", async (t) =>
   assert.equal((await checkForUpdate()).version, "3.10.0");
   for (const status of [403, 404, 429, 500]) {
     t.mock.method(globalThis, "fetch", async () => new Response(null, { status }));
-    await assert.rejects(checkForUpdate());
+    await assert.rejects(checkForUpdate(), UpdateCheckError);
   }
+});
+
+test("every failure this module raises is one it authored", async (t) => {
+  // The displayed line is gated on the type, so anything left as a bare Error
+  // would silently fall back to the generic message.
+  assert.throws(() => isNewerVersion("3.5", "3.5.0"), UpdateCheckError);
+  assert.throws(() => isNewerVersion("9007199254740993.0.0", "3.5.0"), UpdateCheckError);
+  assert.throws(() => parseRelease(null), UpdateCheckError);
+  assert.throws(() => parseRelease({ ...release(), draft: true }), UpdateCheckError);
+  assert.throws(() => parseRelease({ ...release(), tag_name: "latest" }), UpdateCheckError);
+  t.mock.method(globalThis, "fetch", async () => new Response("<html>rate limited</html>"));
+  await assert.rejects(checkForUpdate(), UpdateCheckError);
+});
+
+test("a body the parser chokes on is never quoted back at the user", async (t) => {
+  // A SyntaxError from JSON.parse can carry a slice of the response, so the
+  // failure must be reported as our own line rather than re-thrown.
+  const body = '{"leaked-token":"ghp_should_never_be_displayed"';
+  t.mock.method(globalThis, "fetch", async () => new Response(body));
+  const raised = await checkForUpdate().then(() => null, (error) => error);
+  assert.ok(raised instanceof UpdateCheckError);
+  assert.doesNotMatch(checkFailureMessage(raised, false), /leaked-token|ghp_/);
+});
+
+test("only authored failures reach the user; the rest get a fixed line", () => {
+  assert.equal(checkFailureMessage(new UpdateCheckError("尚无公开的正式版本。"), false),
+    "无法检查更新：尚无公开的正式版本。");
+  const generic = "无法检查更新，请检查网络后重试。";
+  for (const foreign of [new SyntaxError('Unexpected token < ... "ghp_secret"'),
+                         new TypeError("Failed to fetch"), "raw string", { message: "ghp_secret" }, null]) {
+    assert.equal(checkFailureMessage(foreign, false), generic);
+  }
+  // Abort wins over everything: the user pressed stop or the timeout fired.
+  assert.equal(checkFailureMessage(new UpdateCheckError("尚无公开的正式版本。"), true),
+    "检查超时或已取消，请重试。");
 });


### PR DESCRIPTION
接 #39 的 review 备注。

## 问题

`VersionPanel` 的 catch 直接打印 `error.message`。大部分确实是 `updates.ts` 自己写的文案，但有两个来源不是：

- `fetch` 自身的 `TypeError`（"Failed to fetch" 之类，对用户没信息量）
- `response.json()` 的 `SyntaxError` —— **JSON 解析错误会把它噎住的那段正文引回来**

`api.github.com` 是无鉴权端点、请求不带任何凭据，所以这从来不是泄露；但把远端正文片段当成错误提示显示，本身也不是错误提示。

## 改动

- 本模块自造的失败统一带 `UpdateCheckError` 类型
- `response.json()` 包一层，正文畸形时转成自己的文案，不再让 `SyntaxError` 冒出去
- 显示哪一行的判断抽成纯函数 `checkFailureMessage(error, aborted)`：非本模块自造的一律给固定文案「无法检查更新，请检查网络后重试。」

抽成纯函数是照 `titleBarInteraction.ts` 的既有做法——规则可以不挂载组件就测到，新增用例测的正是这条规则。

## 验证

desktop 35/35、`tsc --noEmit` 干净、`vite build` 成功。

新增 3 组测试，都验证过会咬（把 `updates.ts` 改回修复前的写法后，三组同时变红）：

- 本模块抛出的每个失败都是 `UpdateCheckError`——显示逻辑按类型分流，漏一个 bare `Error` 就会静默掉进兜底文案
- 畸形正文（`{"leaked-token":"ghp_..."` ）不会被引回给用户
- 只有自造失败原样显示，`SyntaxError` / `TypeError` / 裸字符串 / 非 Error 对象 / `null` 全部走固定文案；abort 优先于一切

🤖 Generated with [Claude Code](https://claude.com/claude-code)
